### PR TITLE
Fix compass preview line desyncing after crossing 360°

### DIFF
--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -1971,9 +1971,10 @@ export function MathWorkbook() {
                 const delta = normalizeSignedAngleDelta(nextAngle - previousAngle);
                 const radiusMm = current.radiusMm ?? Math.hypot(current.current.xMm - current.center.xMm, current.current.yMm - current.center.yMm);
                 const clampedSweep = Math.max(-Math.PI * 2, Math.min(Math.PI * 2, current.accumulatedSweep + delta));
+                const arcEndAngle = (current.startAngle ?? nextAngle) + clampedSweep;
                 const projectedPoint = {
-                  xMm: current.center.xMm + Math.cos(nextAngle) * radiusMm,
-                  yMm: current.center.yMm + Math.sin(nextAngle) * radiusMm
+                  xMm: current.center.xMm + Math.cos(arcEndAngle) * radiusMm,
+                  yMm: current.center.yMm + Math.sin(arcEndAngle) * radiusMm
                 };
 
                 return {


### PR DESCRIPTION
## Summary

- `projectedPoint` (the preview line endpoint) was computed from the raw `atan2` angle (`nextAngle`), while the arc endpoint uses `startAngle + clampedSweep`
- These diverge once `accumulatedSweep` is clamped at 2π and the user reverses direction, causing the line to visually disconnect from the mouse pointer
- Fix: derive `projectedPoint` from `arcEndAngle = startAngle + clampedSweep` so the line always tracks the arc endpoint

Closes #1

## Test plan

- [ ] Open the compass tool
- [ ] Set center and radius
- [ ] Rotate past 360° in a continuous motion
- [ ] Reverse direction and verify the preview line stays connected to the mouse pointer


Result: 

![Mar-23-2026 22-09-27](https://github.com/user-attachments/assets/9f5b04bf-05ff-44a2-a5e2-a32721b3a452)

