### PR TITLE
Fix canvas quick menu positioning and improve small screen UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,11 @@ coverage
 dev-*.out
 dev-*.err
 .DS_Store
+.AppleDouble
+.LSOverride
+._*
 Thumbs.db
+
+# IntelliJ / JetBrains
+.idea/
+*.iml

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+- Take new screenshot. 

--- a/app/globals.css
+++ b/app/globals.css
@@ -851,6 +851,9 @@ input {
 }
 
 .toolbar-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   border-radius: 999px;
   padding: 0.75rem 0.98rem;
   font-weight: 800;
@@ -2693,8 +2696,7 @@ input {
 .document-canvas-viewport {
   width: 100%;
   overflow: auto;
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable both-edges;
+  scrollbar-gutter: stable;
   padding-bottom: 0.35rem;
 }
 
@@ -3582,7 +3584,7 @@ input {
 
 @media (max-width: 760px) {
   .document-canvas {
-    width: 100%;
+    min-width: var(--a4-width);
   }
 
   .canvas-editor {

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -2814,15 +2814,28 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     setCanvasQuickMenu(null);
   }
 
+  function getCanvasQuickMenuPosition(px: number, py: number) {
+    const size = getCanvasIntrinsicSize();
+    const flipX = px > size.width / 2;
+    const flipY = py > size.height / 2;
+
+    return {
+      ...(flipX ? { right: size.width - px + CANVAS_QUICK_MENU_OFFSET_X } : { left: px + CANVAS_QUICK_MENU_OFFSET_X }),
+      ...(flipY ? { bottom: size.height - py + CANVAS_QUICK_MENU_OFFSET_X } : { top: py }),
+      clickX: px,
+      clickY: py
+    };
+  }
+
   function openCanvasQuickMenu(clientX: number, clientY: number) {
     const point = getCanvasPoint(clientX, clientY);
-    setCanvasQuickMenu({ x: point.x + CANVAS_QUICK_MENU_OFFSET_X, y: point.y, clickX: point.x, clickY: point.y });
+    setCanvasQuickMenu(getCanvasQuickMenuPosition(point.x, point.y));
     clearFloatingSelection();
     setOpenMenu(null);
   }
 
   function openCanvasQuickMenuAtPoint(x: number, y: number) {
-    setCanvasQuickMenu({ x: x + CANVAS_QUICK_MENU_OFFSET_X, y, clickX: x, clickY: y });
+    setCanvasQuickMenu(getCanvasQuickMenuPosition(x, y));
     clearFloatingSelection();
     setOpenMenu(null);
   }

--- a/components/math-workbook/presentational.tsx
+++ b/components/math-workbook/presentational.tsx
@@ -502,12 +502,25 @@ export function WorkbookActionBar({
     <div className="sheet-action-bar">
       <div className="sheet-action-group">
         <button type="button" className="toolbar-action ghost tablet-tools-toggle" onClick={onOpenTools} disabled={!canOpenTools}>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
           {t("toolbar.tools")}
         </button>
         <button type="button" className="toolbar-action ghost" onClick={onUndo} disabled={!canUndo}>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 10h13a4 4 0 0 1 0 8H12" />
+            <polyline points="7 6 3 10 7 14" />
+          </svg>
           {t("toolbar.undo")}
         </button>
         <button type="button" className="toolbar-action ghost" onClick={onRedo} disabled={!canRedo}>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 10H8a4 4 0 0 0 0 8h5" />
+            <polyline points="17 6 21 10 17 14" />
+          </svg>
           {t("toolbar.redo")}
         </button>
       </div>
@@ -1173,7 +1186,7 @@ export function CanvasQuickInsertMenu({
   return (
     <>
       <div className="canvas-quick-anchor" style={{left: `${menu.clickX}px`, top: `${menu.clickY}px`}} aria-hidden="true" />
-      <div className="canvas-quick-menu" style={{left: `${menu.x}px`, top: `${menu.y}px`}} onMouseDown={(event) => event.stopPropagation()}>
+      <div className="canvas-quick-menu" style={{left: menu.left != null ? `${menu.left}px` : undefined, right: menu.right != null ? `${menu.right}px` : undefined, top: menu.top != null ? `${menu.top}px` : undefined, bottom: menu.bottom != null ? `${menu.bottom}px` : undefined}} onMouseDown={(event) => event.stopPropagation()}>
         <button type="button" className="canvas-quick-close" aria-label={t("canvas.closeMenu")} title={t("canvas.closeMenu")} onClick={onClose}>
           ×
         </button>

--- a/components/math-workbook/shared.tsx
+++ b/components/math-workbook/shared.tsx
@@ -371,8 +371,10 @@ export type EditingBlockState =
 
 export type CanvasQuickMenu =
   | {
-      x: number;
-      y: number;
+      left?: number;
+      right?: number;
+      top?: number;
+      bottom?: number;
       clickX: number;
       clickY: number;
     }


### PR DESCRIPTION
- Fix quick menu clipped on right/bottom edges by using right/bottom CSS positioning
- Prevent canvas from shrinking on small screens to avoid hiding drawn elements
- Add icons to toolbar action buttons (tools, undo, redo)
- Fix toolbar button vertical text alignment
- Remove overscroll-behavior to allow page scroll propagation
- Update scrollbar-gutter to prevent scroll shift on menu open
- Add IntelliJ and macOS entries to .gitignore