### PR TITLE
📦 Multi-document localStorage storage with file import/export

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4035,3 +4035,117 @@ input {
     page-break-inside: avoid;
   }
 }
+
+/* -----------------------------------------------------------------------
+   Document switcher (action bar dropdown)
+   ----------------------------------------------------------------------- */
+
+.document-switcher {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.document-switcher-select {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.document-switcher-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.4rem;
+  min-height: 2.4rem;
+  border-radius: 50%;
+  border: 1px solid rgba(92, 108, 129, 0.16);
+  background: rgba(255, 252, 247, 0.94);
+  color: color-mix(in srgb, var(--ink) 50%, white);
+  pointer-events: none;
+}
+
+/* -----------------------------------------------------------------------
+   Document Manager Modal
+   ----------------------------------------------------------------------- */
+
+.document-manager-modal {
+  width: min(600px, 100%);
+}
+
+.document-manager-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 50vh;
+  overflow-y: auto;
+  padding: 0.2rem 0;
+}
+
+.document-manager-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.document-manager-item:hover {
+  background: rgba(92, 108, 129, 0.06);
+}
+
+.document-manager-item-active {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+.document-manager-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.document-manager-item-name {
+  font-weight: 600;
+  font-size: 0.92rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.document-manager-item-date {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--ink) 50%, transparent);
+}
+
+.document-manager-rename-input {
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius: 6px;
+  outline: none;
+  width: 100%;
+}
+
+.document-manager-actions {
+  display: flex;
+  gap: 0.3rem;
+  flex-shrink: 0;
+}
+
+.document-manager-actions .small-action {
+  padding: 0.3rem 0.4rem;
+}
+
+.document-manager-actions .small-action:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4037,115 +4037,134 @@ input {
 }
 
 /* -----------------------------------------------------------------------
-   Document switcher (action bar dropdown)
+   Page navigator (custom dropdown + delete)
    ----------------------------------------------------------------------- */
 
-.document-switcher {
+.page-navigator {
   position: relative;
   display: inline-flex;
   align-items: center;
+  gap: 0.2rem;
 }
 
-.document-switcher-select {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  cursor: pointer;
-  font-size: 1rem;
-}
-
-.document-switcher-badge {
+.page-nav-toggle {
+  appearance: none;
+  -webkit-appearance: none;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  min-width: 2.4rem;
-  min-height: 2.4rem;
-  border-radius: 50%;
-  border: 1px solid rgba(92, 108, 129, 0.16);
-  background: rgba(255, 252, 247, 0.94);
-  color: color-mix(in srgb, var(--ink) 50%, white);
-  pointer-events: none;
-}
-
-/* -----------------------------------------------------------------------
-   Document Manager Modal
-   ----------------------------------------------------------------------- */
-
-.document-manager-modal {
-  width: min(600px, 100%);
-}
-
-.document-manager-list {
-  display: flex;
-  flex-direction: column;
   gap: 0.35rem;
-  max-height: 50vh;
-  overflow-y: auto;
-  padding: 0.2rem 0;
-}
-
-.document-manager-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.8rem;
-  padding: 0.6rem 0.8rem;
-  border-radius: 12px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid rgba(92, 108, 129, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 252, 247, 0.94);
+  color: var(--ink);
   cursor: pointer;
-  transition: background 0.12s;
+  min-height: 2rem;
+  white-space: nowrap;
+  transition: background 0.1s;
 }
 
-.document-manager-item:hover {
+.page-nav-toggle:hover {
   background: rgba(92, 108, 129, 0.06);
 }
 
-.document-manager-item-active {
+.page-menu-dropdown,
+.file-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  bottom: auto;
+  z-index: 100;
+  padding: 0.3rem;
+  border: 1px solid rgba(92, 108, 129, 0.14);
+  border-radius: 12px;
+  background: rgba(255, 253, 249, 0.98);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.page-menu-dropdown {
+  left: 0;
+  right: auto;
+  min-width: 8rem;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.page-menu-item-active {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+  font-weight: 700;
 }
 
-.document-manager-item-info {
+.page-nav-delete {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border: 1px solid rgba(92, 108, 129, 0.12);
+  border-radius: 8px;
+  background: none;
+  color: color-mix(in srgb, var(--ink) 35%, transparent);
+  cursor: pointer;
+  transition: color 0.1s, background 0.1s;
+}
+
+.page-nav-delete:hover {
+  color: #c0392b;
+  background: rgba(192, 57, 43, 0.08);
+  border-color: rgba(192, 57, 43, 0.15);
+}
+
+/* -----------------------------------------------------------------------
+   File menu dropdown
+   ----------------------------------------------------------------------- */
+
+.file-menu-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.file-menu-dropdown {
+  right: 0;
+  left: auto;
+  min-width: 12rem;
+}
+
+.file-menu-item {
+  appearance: none;
+  -webkit-appearance: none;
   display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  min-width: 0;
-  flex: 1;
-}
-
-.document-manager-item-name {
-  font-weight: 600;
-  font-size: 0.92rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.document-manager-item-date {
-  font-size: 0.75rem;
-  color: color-mix(in srgb, var(--ink) 50%, transparent);
-}
-
-.document-manager-rename-input {
-  font-size: 0.92rem;
-  font-weight: 600;
-  padding: 0.2rem 0.4rem;
-  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
-  border-radius: 6px;
-  outline: none;
+  align-items: center;
+  gap: 0.5rem;
   width: 100%;
+  padding: 0.5rem 0.6rem;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  color: var(--ink);
+  font-size: 0.88rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s;
 }
 
-.document-manager-actions {
-  display: flex;
-  gap: 0.3rem;
-  flex-shrink: 0;
+.file-menu-item:hover {
+  background: rgba(92, 108, 129, 0.06);
 }
 
-.document-manager-actions .small-action {
-  padding: 0.3rem 0.4rem;
+.file-menu-item-danger {
+  color: #c0392b;
 }
 
-.document-manager-actions .small-action:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
+.file-menu-item-danger:hover {
+  background: rgba(192, 57, 43, 0.06);
+}
+
+.file-menu-separator {
+  border: none;
+  border-top: 1px solid rgba(92, 108, 129, 0.1);
+  margin: 0.2rem 0.4rem;
 }

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -34,6 +34,8 @@ import {
 import {
   CanvasQuickInsertMenu,
   ConfirmResetModal,
+  ConfirmDeleteDocumentModal,
+  DocumentManagerModal,
   ProfileModal,
   GeometrySettingsMenu,
   GraduatedLineModal,
@@ -44,6 +46,21 @@ import {
   WorkbookActionBar,
   WorkbookSidebar
 } from "@/components/math-workbook/presentational";
+import {
+  type DocumentIndex,
+  type DocumentMeta,
+  loadDocumentIndex,
+  saveDocumentIndex,
+  loadDocumentState,
+  saveDocumentState,
+  createDocument,
+  renameDocument,
+  deleteDocument,
+  duplicateDocument,
+  migrateFromLegacyStorage,
+  exportDocumentToFile,
+  parseImportedFile
+} from "@/components/math-workbook/document-store";
 import type {
   StudyMode,
   SheetStyle,
@@ -111,9 +128,7 @@ import type {
   ProfileStore
 } from "@/components/math-workbook/shared";
 import {
-  STORAGE_KEY,
   PROFILE_STORAGE_KEY,
-  WRITER_STATE_SCHEMA_VERSION,
   FLOATING_TEXTBOX_Y_OFFSET,
   CANVAS_QUICK_MENU_OFFSET_X,
   MAX_HISTORY_STEPS,
@@ -203,7 +218,6 @@ import {
   areWriterStatesEqual,
   getGridDimensions,
   getRemPixels,
-  parseStoredState,
   parseStoredProfiles,
   getDocumentLabelsForProfile,
   getDefaultWidth,
@@ -304,6 +318,10 @@ export function MathWorkbook() {
   const [isInstalledApp, setIsInstalledApp] = useState(false);
   const [profileStore, setProfileStore] = useState<ProfileStore>({ profiles: [], activeProfileId: null });
   const [profileEditMode, setProfileEditMode] = useState<"create" | "edit" | null>(null);
+  const [documentIndex, setDocumentIndex] = useState<DocumentIndex>({ version: 1, activeDocumentId: null, documents: [] });
+  const [documentManagerOpen, setDocumentManagerOpen] = useState(false);
+  const [confirmDeleteDocId, setConfirmDeleteDocId] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const activeProfile = useMemo(
     () => profileStore.profiles.find((p) => p.id === profileStore.activeProfileId) ?? null,
     [profileStore]
@@ -750,21 +768,33 @@ export function MathWorkbook() {
   }, [pendingInsertTool, activeInlineShortcuts, activeStructuredTools, t, workbookUi.blockTitles.default]);
 
   useEffect(() => {
+    let index = loadDocumentIndex();
+
+    if (index.documents.length === 0) {
+      index = migrateFromLegacyStorage(defaultSheetStyle, workbookUi.defaultDocumentLabels);
+    }
+
+    if (index.documents.length === 0) {
+      const defaultState = createDefaultState(defaultSheetStyle, workbookUi.defaultDocumentLabels);
+      createDocument(workbookUi.defaultDocumentLabels.title, defaultState);
+      index = loadDocumentIndex();
+    }
+
+    const activeId = index.activeDocumentId ?? index.documents[0]?.id;
+
+    if (activeId) {
+      const loaded = loadDocumentState(activeId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+
+      if (loaded) {
+        setState(loaded);
+      }
+
+      index = { ...index, activeDocumentId: activeId };
+      saveDocumentIndex(index);
+    }
+
+    setDocumentIndex(index);
     setIsHydrated(true);
-    const saved = window.localStorage.getItem(STORAGE_KEY);
-
-    if (!saved) {
-      return;
-    }
-
-    const parsed = parseStoredState(saved, defaultSheetStyle, workbookUi.defaultDocumentLabels);
-
-    if (!parsed) {
-      window.localStorage.removeItem(STORAGE_KEY);
-      return;
-    }
-
-    setState(parsed);
   }, [defaultSheetStyle, workbookUi.defaultDocumentLabels]);
 
   useEffect(() => {
@@ -780,12 +810,12 @@ export function MathWorkbook() {
   }, []);
 
   useEffect(() => {
-    if (!isHydrated) {
+    if (!isHydrated || !documentIndex.activeDocumentId) {
       return;
     }
 
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-  }, [isHydrated, state]);
+    saveDocumentState(documentIndex.activeDocumentId, state);
+  }, [isHydrated, state, documentIndex.activeDocumentId]);
 
   useEffect(() => {
     const saved = window.localStorage.getItem(PROFILE_STORAGE_KEY);
@@ -4879,7 +4909,6 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
   function confirmResetDocument() {
     const labels = getDocumentLabelsForProfile(activeProfile, workbookUi.defaultDocumentLabels, locale);
     const sheetStyle = activeProfile?.preferredSheetStyle ?? defaultSheetStyle;
-    window.localStorage.removeItem(STORAGE_KEY);
     const newState = createDefaultState(sheetStyle, labels);
 
     if (activeProfile) {
@@ -4902,9 +4931,146 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     setConfirmResetState(null);
     clearFloatingSelection();
     selectionRef.current = null;
+    setHistoryPast([]);
+    setHistoryFuture([]);
     if (editorRef.current) {
       editorRef.current.innerHTML = DEFAULT_TEXT_HTML;
     }
+  }
+
+  function clearTransientState() {
+    setOpenMenu(null);
+    setCanvasQuickMenu(null);
+    setModalState(null);
+    setConfirmResetState(null);
+    clearGraduatedLineDraftState();
+    clearFloatingSelection();
+    selectionRef.current = null;
+    setEditingBlock(null);
+    setEditingTextBoxId(null);
+    setHistoryPast([]);
+    setHistoryFuture([]);
+    if (editorRef.current) {
+      editorRef.current.innerHTML = DEFAULT_TEXT_HTML;
+    }
+  }
+
+  function handleSwitchDocument(docId: string) {
+    if (docId === documentIndex.activeDocumentId) return;
+
+    const loaded = loadDocumentState(docId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+    if (!loaded) return;
+
+    clearTransientState();
+    setState(loaded);
+
+    const newIndex = { ...documentIndex, activeDocumentId: docId };
+    saveDocumentIndex(newIndex);
+    setDocumentIndex(newIndex);
+    setDocumentManagerOpen(false);
+  }
+
+  function handleNewDocument() {
+    const labels = getDocumentLabelsForProfile(activeProfile, workbookUi.defaultDocumentLabels, locale);
+    const sheetStyle = activeProfile?.preferredSheetStyle ?? defaultSheetStyle;
+    const newState = createDefaultState(sheetStyle, labels);
+
+    if (activeProfile) {
+      newState.mode = activeProfile.preferredMode;
+
+      if (newState.textBoxes.length >= 3) {
+        if (!activeProfile.showName) newState.textBoxes[0] = { ...newState.textBoxes[0], hidden: true };
+        if (!activeProfile.showClass) newState.textBoxes[1] = { ...newState.textBoxes[1], hidden: true };
+        if (!activeProfile.showDate) newState.textBoxes[2] = { ...newState.textBoxes[2], hidden: true };
+      }
+
+      newState.textBoxes = applyHeaderPositions(newState.textBoxes, activeProfile);
+    }
+
+    const meta = createDocument(newState.title, newState);
+    clearTransientState();
+    setState(newState);
+    setDocumentIndex(loadDocumentIndex());
+    setDocumentManagerOpen(false);
+  }
+
+  function handleDuplicateDocument(docId: string) {
+    const meta = documentIndex.documents.find((d) => d.id === docId);
+    if (!meta) return;
+
+    const newName = meta.name + t("documentManager.duplicateSuffix");
+    const newMeta = duplicateDocument(docId, newName, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+    if (!newMeta) return;
+
+    setDocumentIndex(loadDocumentIndex());
+    handleSwitchDocument(newMeta.id);
+  }
+
+  function handleDeleteDocument(docId: string) {
+    setConfirmDeleteDocId(docId);
+  }
+
+  function handleConfirmDeleteDocument() {
+    if (!confirmDeleteDocId) return;
+
+    const wasActive = confirmDeleteDocId === documentIndex.activeDocumentId;
+    deleteDocument(confirmDeleteDocId);
+    const newIndex = loadDocumentIndex();
+    setDocumentIndex(newIndex);
+    setConfirmDeleteDocId(null);
+
+    if (wasActive && newIndex.documents.length > 0) {
+      handleSwitchDocument(newIndex.activeDocumentId ?? newIndex.documents[0].id);
+    }
+  }
+
+  function handleRenameDocument(docId: string, name: string) {
+    renameDocument(docId, name);
+    setDocumentIndex(loadDocumentIndex());
+  }
+
+  function handleExportDocumentFile(docId?: string) {
+    const targetId = docId ?? documentIndex.activeDocumentId;
+    if (!targetId) return;
+
+    const meta = documentIndex.documents.find((d) => d.id === targetId);
+    if (!meta) return;
+
+    if (targetId === documentIndex.activeDocumentId) {
+      exportDocumentToFile(meta, state);
+    } else {
+      const docState = loadDocumentState(targetId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+      if (docState) exportDocumentToFile(meta, docState);
+    }
+  }
+
+  function handleImportDocumentFile() {
+    fileInputRef.current?.click();
+  }
+
+  function handleFileInputChange(event: ReactChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const raw = reader.result as string;
+      const result = parseImportedFile(raw, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+
+      if (!result) {
+        window.alert(t("documentManager.importError"));
+        return;
+      }
+
+      const meta = createDocument(result.name, result.state);
+      clearTransientState();
+      setState(result.state);
+      setDocumentIndex(loadDocumentIndex());
+      setDocumentManagerOpen(false);
+    };
+
+    reader.readAsText(file);
+    event.target.value = "";
   }
 
   function applyHeaderPositions(textBoxes: FloatingTextBox[], profile: UserProfile): FloatingTextBox[] {
@@ -5311,14 +5477,21 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
           isExporting={isExporting}
           sheetStyle={state.sheetStyle}
           sheetStyleOptions={workbookUi.sheetStyleOptions}
+          documents={documentIndex.documents}
+          activeDocumentId={documentIndex.activeDocumentId}
           onOpenTools={() => setIsToolsPanelOpen(true)}
           onUndo={undoHistory}
           onRedo={redoHistory}
           onExportPdf={exportPdf}
           onExportPng={exportPng}
           onPrint={printSheet}
+          onExportDocumentFile={() => handleExportDocumentFile()}
           onSheetStyleChange={(sheetStyle) => setState((current) => ({...current, sheetStyle}))}
           onResetDocument={resetDocument}
+          onSwitchDocument={handleSwitchDocument}
+          onNewDocument={handleNewDocument}
+          onImportDocument={handleImportDocumentFile}
+          onOpenDocumentManager={() => setDocumentManagerOpen(true)}
           profiles={profileStore.profiles}
           activeProfileId={profileStore.activeProfileId}
           onProfileChange={handleProfileChange}
@@ -5825,6 +5998,34 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
         confirmResetState={confirmResetState}
         onClose={() => setConfirmResetState(null)}
         onConfirm={confirmResetDocument}
+      />
+      {documentManagerOpen ? (
+        <DocumentManagerModal
+          t={t}
+          documents={documentIndex.documents}
+          activeDocumentId={documentIndex.activeDocumentId}
+          onSwitchDocument={handleSwitchDocument}
+          onRenameDocument={handleRenameDocument}
+          onDuplicateDocument={handleDuplicateDocument}
+          onDeleteDocument={handleDeleteDocument}
+          onExportDocument={(docId) => handleExportDocumentFile(docId)}
+          onImportDocument={handleImportDocumentFile}
+          onClose={() => setDocumentManagerOpen(false)}
+        />
+      ) : null}
+      {confirmDeleteDocId ? (
+        <ConfirmDeleteDocumentModal
+          t={t}
+          onClose={() => setConfirmDeleteDocId(null)}
+          onConfirm={handleConfirmDeleteDocument}
+        />
+      ) : null}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".dysmaths,.json"
+        style={{ display: "none" }}
+        onChange={handleFileInputChange}
       />
       {profileEditMode ? (
         <ProfileModal

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -34,8 +34,6 @@ import {
 import {
   CanvasQuickInsertMenu,
   ConfirmResetModal,
-  ConfirmDeleteDocumentModal,
-  DocumentManagerModal,
   ProfileModal,
   GeometrySettingsMenu,
   GraduatedLineModal,
@@ -47,18 +45,15 @@ import {
   WorkbookSidebar
 } from "@/components/math-workbook/presentational";
 import {
-  type DocumentIndex,
-  type DocumentMeta,
-  loadDocumentIndex,
-  saveDocumentIndex,
-  loadDocumentState,
-  saveDocumentState,
-  createDocument,
-  renameDocument,
-  deleteDocument,
-  duplicateDocument,
+  type PageIndex,
+  loadPageIndex,
+  savePageIndex,
+  loadPageState,
+  savePageState,
+  createPage,
+  deletePage,
   migrateFromLegacyStorage,
-  exportDocumentToFile,
+  exportPageToFile,
   parseImportedFile
 } from "@/components/math-workbook/document-store";
 import type {
@@ -318,9 +313,8 @@ export function MathWorkbook() {
   const [isInstalledApp, setIsInstalledApp] = useState(false);
   const [profileStore, setProfileStore] = useState<ProfileStore>({ profiles: [], activeProfileId: null });
   const [profileEditMode, setProfileEditMode] = useState<"create" | "edit" | null>(null);
-  const [documentIndex, setDocumentIndex] = useState<DocumentIndex>({ version: 1, activeDocumentId: null, documents: [] });
-  const [documentManagerOpen, setDocumentManagerOpen] = useState(false);
-  const [confirmDeleteDocId, setConfirmDeleteDocId] = useState<string | null>(null);
+  const [pageIndex, setPageIndex] = useState<PageIndex>({ version: 1, activePageId: null, pages: [] });
+  const [confirmDeleteAllOpen, setConfirmDeleteAllOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const activeProfile = useMemo(
     () => profileStore.profiles.find((p) => p.id === profileStore.activeProfileId) ?? null,
@@ -768,32 +762,32 @@ export function MathWorkbook() {
   }, [pendingInsertTool, activeInlineShortcuts, activeStructuredTools, t, workbookUi.blockTitles.default]);
 
   useEffect(() => {
-    let index = loadDocumentIndex();
+    let index = loadPageIndex();
 
-    if (index.documents.length === 0) {
+    if (index.pages.length === 0) {
       index = migrateFromLegacyStorage(defaultSheetStyle, workbookUi.defaultDocumentLabels);
     }
 
-    if (index.documents.length === 0) {
+    if (index.pages.length === 0) {
       const defaultState = createDefaultState(defaultSheetStyle, workbookUi.defaultDocumentLabels);
-      createDocument(workbookUi.defaultDocumentLabels.title, defaultState);
-      index = loadDocumentIndex();
+      createPage(workbookUi.defaultDocumentLabels.title, defaultState);
+      index = loadPageIndex();
     }
 
-    const activeId = index.activeDocumentId ?? index.documents[0]?.id;
+    const activeId = index.activePageId ?? index.pages[0]?.id;
 
     if (activeId) {
-      const loaded = loadDocumentState(activeId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+      const loaded = loadPageState(activeId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
 
       if (loaded) {
         setState(loaded);
       }
 
-      index = { ...index, activeDocumentId: activeId };
-      saveDocumentIndex(index);
+      index = { ...index, activePageId: activeId };
+      savePageIndex(index);
     }
 
-    setDocumentIndex(index);
+    setPageIndex(index);
     setIsHydrated(true);
   }, [defaultSheetStyle, workbookUi.defaultDocumentLabels]);
 
@@ -810,12 +804,12 @@ export function MathWorkbook() {
   }, []);
 
   useEffect(() => {
-    if (!isHydrated || !documentIndex.activeDocumentId) {
+    if (!isHydrated || !pageIndex.activePageId) {
       return;
     }
 
-    saveDocumentState(documentIndex.activeDocumentId, state);
-  }, [isHydrated, state, documentIndex.activeDocumentId]);
+    savePageState(pageIndex.activePageId, state);
+  }, [isHydrated, state, pageIndex.activePageId]);
 
   useEffect(() => {
     const saved = window.localStorage.getItem(PROFILE_STORAGE_KEY);
@@ -4902,11 +4896,7 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
 
     return renderBasicInlineEditor(block as FractionBlock | PowerBlock | RootBlock, bindInlineInput as never);
   }
-  function resetDocument() {
-    setConfirmResetState({ open: true });
-  }
-
-  function confirmResetDocument() {
+  function createProfileAwareDefaultState(): WriterState {
     const labels = getDocumentLabelsForProfile(activeProfile, workbookUi.defaultDocumentLabels, locale);
     const sheetStyle = activeProfile?.preferredSheetStyle ?? defaultSheetStyle;
     const newState = createDefaultState(sheetStyle, labels);
@@ -4923,19 +4913,14 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
       newState.textBoxes = applyHeaderPositions(newState.textBoxes, activeProfile);
     }
 
+    return newState;
+  }
+
+  function confirmResetDocument() {
+    const newState = createProfileAwareDefaultState();
+    clearTransientState();
     setState(newState);
-    setOpenMenu(null);
-    setCanvasQuickMenu(null);
-    setModalState(null);
-    clearGraduatedLineDraftState();
     setConfirmResetState(null);
-    clearFloatingSelection();
-    selectionRef.current = null;
-    setHistoryPast([]);
-    setHistoryFuture([]);
-    if (editorRef.current) {
-      editorRef.current.innerHTML = DEFAULT_TEXT_HTML;
-    }
   }
 
   function clearTransientState() {
@@ -4955,96 +4940,66 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     }
   }
 
-  function handleSwitchDocument(docId: string) {
-    if (docId === documentIndex.activeDocumentId) return;
+  function handleSwitchPage(pageId: string) {
+    if (pageId === pageIndex.activePageId) return;
 
-    const loaded = loadDocumentState(docId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+    const loaded = loadPageState(pageId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
     if (!loaded) return;
 
     clearTransientState();
     setState(loaded);
 
-    const newIndex = { ...documentIndex, activeDocumentId: docId };
-    saveDocumentIndex(newIndex);
-    setDocumentIndex(newIndex);
-    setDocumentManagerOpen(false);
+    const newIndex = { ...pageIndex, activePageId: pageId };
+    savePageIndex(newIndex);
+    setPageIndex(newIndex);
   }
 
-  function handleNewDocument() {
-    const labels = getDocumentLabelsForProfile(activeProfile, workbookUi.defaultDocumentLabels, locale);
-    const sheetStyle = activeProfile?.preferredSheetStyle ?? defaultSheetStyle;
-    const newState = createDefaultState(sheetStyle, labels);
-
-    if (activeProfile) {
-      newState.mode = activeProfile.preferredMode;
-
-      if (newState.textBoxes.length >= 3) {
-        if (!activeProfile.showName) newState.textBoxes[0] = { ...newState.textBoxes[0], hidden: true };
-        if (!activeProfile.showClass) newState.textBoxes[1] = { ...newState.textBoxes[1], hidden: true };
-        if (!activeProfile.showDate) newState.textBoxes[2] = { ...newState.textBoxes[2], hidden: true };
-      }
-
-      newState.textBoxes = applyHeaderPositions(newState.textBoxes, activeProfile);
-    }
-
-    const meta = createDocument(newState.title, newState);
+  function handleNewPage() {
+    const newState = createProfileAwareDefaultState();
+    createPage(newState.title, newState);
     clearTransientState();
     setState(newState);
-    setDocumentIndex(loadDocumentIndex());
-    setDocumentManagerOpen(false);
+    setPageIndex(loadPageIndex());
   }
 
-  function handleDuplicateDocument(docId: string) {
-    const meta = documentIndex.documents.find((d) => d.id === docId);
-    if (!meta) return;
+  function handleDeletePage(pageId: string) {
+    if (pageIndex.pages.length <= 1) return;
+    if (!window.confirm(t("pages.deletePageConfirm"))) return;
 
-    const newName = meta.name + t("documentManager.duplicateSuffix");
-    const newMeta = duplicateDocument(docId, newName, defaultSheetStyle, workbookUi.defaultDocumentLabels);
-    if (!newMeta) return;
+    const wasActive = pageId === pageIndex.activePageId;
+    deletePage(pageId);
+    const newIndex = loadPageIndex();
+    setPageIndex(newIndex);
 
-    setDocumentIndex(loadDocumentIndex());
-    handleSwitchDocument(newMeta.id);
-  }
-
-  function handleDeleteDocument(docId: string) {
-    setConfirmDeleteDocId(docId);
-  }
-
-  function handleConfirmDeleteDocument() {
-    if (!confirmDeleteDocId) return;
-
-    const wasActive = confirmDeleteDocId === documentIndex.activeDocumentId;
-    deleteDocument(confirmDeleteDocId);
-    const newIndex = loadDocumentIndex();
-    setDocumentIndex(newIndex);
-    setConfirmDeleteDocId(null);
-
-    if (wasActive && newIndex.documents.length > 0) {
-      handleSwitchDocument(newIndex.activeDocumentId ?? newIndex.documents[0].id);
+    if (wasActive && newIndex.pages.length > 0) {
+      handleSwitchPage(newIndex.activePageId ?? newIndex.pages[0].id);
     }
   }
 
-  function handleRenameDocument(docId: string, name: string) {
-    renameDocument(docId, name);
-    setDocumentIndex(loadDocumentIndex());
+  function handleDeleteAllPages() {
+    setConfirmDeleteAllOpen(true);
   }
 
-  function handleExportDocumentFile(docId?: string) {
-    const targetId = docId ?? documentIndex.activeDocumentId;
+  function confirmDeleteAllPages() {
+    for (const page of pageIndex.pages) {
+      deletePage(page.id);
+    }
+
+    handleNewPage();
+    setConfirmDeleteAllOpen(false);
+  }
+
+  function handleExportFile() {
+    const targetId = pageIndex.activePageId;
     if (!targetId) return;
 
-    const meta = documentIndex.documents.find((d) => d.id === targetId);
+    const meta = pageIndex.pages.find((d) => d.id === targetId);
     if (!meta) return;
 
-    if (targetId === documentIndex.activeDocumentId) {
-      exportDocumentToFile(meta, state);
-    } else {
-      const docState = loadDocumentState(targetId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
-      if (docState) exportDocumentToFile(meta, docState);
-    }
+    exportPageToFile(meta, state);
   }
 
-  function handleImportDocumentFile() {
+  function handleImportFile() {
     fileInputRef.current?.click();
   }
 
@@ -5058,15 +5013,14 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
       const result = parseImportedFile(raw, defaultSheetStyle, workbookUi.defaultDocumentLabels);
 
       if (!result) {
-        window.alert(t("documentManager.importError"));
+        window.alert(t("pages.importError"));
         return;
       }
 
-      const meta = createDocument(result.name, result.state);
+      createPage(result.name, result.state);
       clearTransientState();
       setState(result.state);
-      setDocumentIndex(loadDocumentIndex());
-      setDocumentManagerOpen(false);
+      setPageIndex(loadPageIndex());
     };
 
     reader.readAsText(file);
@@ -5477,21 +5431,21 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
           isExporting={isExporting}
           sheetStyle={state.sheetStyle}
           sheetStyleOptions={workbookUi.sheetStyleOptions}
-          documents={documentIndex.documents}
-          activeDocumentId={documentIndex.activeDocumentId}
+          pages={pageIndex.pages}
+          activePageId={pageIndex.activePageId}
           onOpenTools={() => setIsToolsPanelOpen(true)}
           onUndo={undoHistory}
           onRedo={redoHistory}
           onExportPdf={exportPdf}
           onExportPng={exportPng}
           onPrint={printSheet}
-          onExportDocumentFile={() => handleExportDocumentFile()}
           onSheetStyleChange={(sheetStyle) => setState((current) => ({...current, sheetStyle}))}
-          onResetDocument={resetDocument}
-          onSwitchDocument={handleSwitchDocument}
-          onNewDocument={handleNewDocument}
-          onImportDocument={handleImportDocumentFile}
-          onOpenDocumentManager={() => setDocumentManagerOpen(true)}
+          onNewPage={handleNewPage}
+          onSwitchPage={handleSwitchPage}
+          onDeletePage={handleDeletePage}
+          onDeleteAllPages={handleDeleteAllPages}
+          onExportFile={handleExportFile}
+          onImportFile={handleImportFile}
           profiles={profileStore.profiles}
           activeProfileId={profileStore.activeProfileId}
           onProfileChange={handleProfileChange}
@@ -5999,26 +5953,26 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
         onClose={() => setConfirmResetState(null)}
         onConfirm={confirmResetDocument}
       />
-      {documentManagerOpen ? (
-        <DocumentManagerModal
-          t={t}
-          documents={documentIndex.documents}
-          activeDocumentId={documentIndex.activeDocumentId}
-          onSwitchDocument={handleSwitchDocument}
-          onRenameDocument={handleRenameDocument}
-          onDuplicateDocument={handleDuplicateDocument}
-          onDeleteDocument={handleDeleteDocument}
-          onExportDocument={(docId) => handleExportDocumentFile(docId)}
-          onImportDocument={handleImportDocumentFile}
-          onClose={() => setDocumentManagerOpen(false)}
-        />
-      ) : null}
-      {confirmDeleteDocId ? (
-        <ConfirmDeleteDocumentModal
-          t={t}
-          onClose={() => setConfirmDeleteDocId(null)}
-          onConfirm={handleConfirmDeleteDocument}
-        />
+      {confirmDeleteAllOpen ? (
+        <div className="modal-backdrop" role="presentation" onClick={() => setConfirmDeleteAllOpen(false)}>
+          <section className="block-modal" role="dialog" aria-modal="true" aria-labelledby="delete-all-modal-title" onClick={(event) => event.stopPropagation()}>
+            <div className="block-modal-head">
+              <div>
+                <p className="card-kind">{t("modal.confirmation")}</p>
+                <h2 id="delete-all-modal-title">{t("pages.deleteAll")}</h2>
+                <p className="toolbar-helper">{t("pages.deleteAllConfirm")}</p>
+              </div>
+              <div className="card-actions">
+                <button type="button" className="small-action" onClick={() => setConfirmDeleteAllOpen(false)}>
+                  {t("modal.cancel")}
+                </button>
+                <button type="button" className="small-action primary-inline-action" onClick={confirmDeleteAllPages}>
+                  {t("pages.deleteAll")}
+                </button>
+              </div>
+            </div>
+          </section>
+        </div>
       ) : null}
       <input
         ref={fileInputRef}

--- a/components/math-workbook/document-store.ts
+++ b/components/math-workbook/document-store.ts
@@ -5,7 +5,6 @@ import {
   type WriterState,
   STORAGE_KEY,
   WRITER_STATE_SCHEMA_VERSION,
-  cloneWriterState,
   parseStoredState,
   safeFileName
 } from "./shared";
@@ -14,17 +13,17 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
-export type DocumentMeta = {
+export type PageMeta = {
   id: string;
   name: string;
   createdAt: string;
   updatedAt: string;
 };
 
-export type DocumentIndex = {
+export type PageIndex = {
   version: number;
-  activeDocumentId: string | null;
-  documents: DocumentMeta[];
+  activePageId: string | null;
+  pages: PageMeta[];
 };
 
 export type DysmathsFile = {
@@ -40,21 +39,22 @@ export type DysmathsFile = {
 // Constants
 // ---------------------------------------------------------------------------
 
-export const DOCUMENT_INDEX_KEY = "dysmaths-documents-v1";
-const DOCUMENT_KEY_PREFIX = "dysmaths-doc-";
-const DOCUMENT_INDEX_VERSION = 1;
+// Keep the legacy localStorage keys for backward compatibility with existing user data
+export const PAGE_INDEX_KEY = "dysmaths-documents-v1";
+const PAGE_KEY_PREFIX = "dysmaths-doc-";
+const PAGE_INDEX_VERSION = 1;
 const DYSMATHS_FILE_VERSION = 1;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getDocumentStorageKey(docId: string): string {
-  return `${DOCUMENT_KEY_PREFIX}${docId}`;
+function getPageStorageKey(pageId: string): string {
+  return `${PAGE_KEY_PREFIX}${pageId}`;
 }
 
-function createEmptyIndex(): DocumentIndex {
-  return { version: DOCUMENT_INDEX_VERSION, activeDocumentId: null, documents: [] };
+function createEmptyIndex(): PageIndex {
+  return { version: PAGE_INDEX_VERSION, activePageId: null, pages: [] };
 }
 
 function nowIso(): string {
@@ -65,25 +65,28 @@ function nowIso(): string {
 // Index operations
 // ---------------------------------------------------------------------------
 
-export function loadDocumentIndex(): DocumentIndex {
+export function loadPageIndex(): PageIndex {
   try {
-    const raw = window.localStorage.getItem(DOCUMENT_INDEX_KEY);
+    const raw = window.localStorage.getItem(PAGE_INDEX_KEY);
 
     if (!raw) {
       return createEmptyIndex();
     }
 
-    const parsed = JSON.parse(raw) as DocumentIndex;
+    const parsed = JSON.parse(raw);
 
-    if (!parsed || !Array.isArray(parsed.documents)) {
+    if (!parsed || !Array.isArray(parsed.documents ?? parsed.pages)) {
       return createEmptyIndex();
     }
 
+    const docs = parsed.documents ?? parsed.pages;
+    const activeId = parsed.activeDocumentId ?? parsed.activePageId;
+
     return {
-      version: DOCUMENT_INDEX_VERSION,
-      activeDocumentId: typeof parsed.activeDocumentId === "string" ? parsed.activeDocumentId : null,
-      documents: parsed.documents.filter(
-        (d) =>
+      version: PAGE_INDEX_VERSION,
+      activePageId: typeof activeId === "string" ? activeId : null,
+      pages: docs.filter(
+        (d: Record<string, unknown>) =>
           d &&
           typeof d.id === "string" &&
           typeof d.name === "string" &&
@@ -96,20 +99,20 @@ export function loadDocumentIndex(): DocumentIndex {
   }
 }
 
-export function saveDocumentIndex(index: DocumentIndex): void {
-  window.localStorage.setItem(DOCUMENT_INDEX_KEY, JSON.stringify(index));
+export function savePageIndex(index: PageIndex): void {
+  window.localStorage.setItem(PAGE_INDEX_KEY, JSON.stringify(index));
 }
 
 // ---------------------------------------------------------------------------
-// Document state operations
+// Page state operations
 // ---------------------------------------------------------------------------
 
-export function loadDocumentState(
-  docId: string,
+export function loadPageState(
+  pageId: string,
   fallbackSheetStyle: SheetStyle,
   labels: DefaultDocumentLabels
 ): WriterState | null {
-  const raw = window.localStorage.getItem(getDocumentStorageKey(docId));
+  const raw = window.localStorage.getItem(getPageStorageKey(pageId));
 
   if (!raw) {
     return null;
@@ -118,16 +121,15 @@ export function loadDocumentState(
   return parseStoredState(raw, fallbackSheetStyle, labels);
 }
 
-export function saveDocumentState(docId: string, state: WriterState): void {
-  window.localStorage.setItem(getDocumentStorageKey(docId), JSON.stringify(state));
+export function savePageState(pageId: string, state: WriterState): void {
+  window.localStorage.setItem(getPageStorageKey(pageId), JSON.stringify(state));
 
-  // Update the updatedAt timestamp in the index
-  const index = loadDocumentIndex();
-  const entry = index.documents.find((d) => d.id === docId);
+  const index = loadPageIndex();
+  const entry = index.pages.find((d) => d.id === pageId);
 
   if (entry) {
     entry.updatedAt = nowIso();
-    saveDocumentIndex(index);
+    savePageIndex(index);
   }
 }
 
@@ -135,63 +137,34 @@ export function saveDocumentState(docId: string, state: WriterState): void {
 // CRUD operations
 // ---------------------------------------------------------------------------
 
-export function createDocument(name: string, state: WriterState): DocumentMeta {
+export function createPage(name: string, state: WriterState): PageMeta {
   const now = nowIso();
-  const meta: DocumentMeta = {
+  const meta: PageMeta = {
     id: crypto.randomUUID(),
     name: name || "Untitled",
     createdAt: now,
     updatedAt: now
   };
 
-  const index = loadDocumentIndex();
-  index.documents.push(meta);
-  index.activeDocumentId = meta.id;
-  saveDocumentIndex(index);
-  window.localStorage.setItem(getDocumentStorageKey(meta.id), JSON.stringify(state));
+  const index = loadPageIndex();
+  index.pages.push(meta);
+  index.activePageId = meta.id;
+  savePageIndex(index);
+  window.localStorage.setItem(getPageStorageKey(meta.id), JSON.stringify(state));
 
   return meta;
 }
 
-export function renameDocument(docId: string, name: string): void {
-  const index = loadDocumentIndex();
-  const entry = index.documents.find((d) => d.id === docId);
+export function deletePage(pageId: string): void {
+  const index = loadPageIndex();
+  index.pages = index.pages.filter((d) => d.id !== pageId);
 
-  if (entry) {
-    entry.name = name;
-    entry.updatedAt = nowIso();
-    saveDocumentIndex(index);
-  }
-}
-
-export function deleteDocument(docId: string): void {
-  const index = loadDocumentIndex();
-  index.documents = index.documents.filter((d) => d.id !== docId);
-
-  if (index.activeDocumentId === docId) {
-    index.activeDocumentId = index.documents[0]?.id ?? null;
+  if (index.activePageId === pageId) {
+    index.activePageId = index.pages[0]?.id ?? null;
   }
 
-  saveDocumentIndex(index);
-  window.localStorage.removeItem(getDocumentStorageKey(docId));
-}
-
-export function duplicateDocument(
-  docId: string,
-  newName: string,
-  fallbackSheetStyle: SheetStyle,
-  labels: DefaultDocumentLabels
-): DocumentMeta | null {
-  const state = loadDocumentState(docId, fallbackSheetStyle, labels);
-
-  if (!state) {
-    return null;
-  }
-
-  const cloned = cloneWriterState(state);
-  cloned.title = newName;
-
-  return createDocument(newName, cloned);
+  savePageIndex(index);
+  window.localStorage.removeItem(getPageStorageKey(pageId));
 }
 
 // ---------------------------------------------------------------------------
@@ -201,26 +174,26 @@ export function duplicateDocument(
 export function migrateFromLegacyStorage(
   fallbackSheetStyle: SheetStyle,
   labels: DefaultDocumentLabels
-): DocumentIndex {
+): PageIndex {
   const raw = window.localStorage.getItem(STORAGE_KEY);
 
   if (!raw) {
-    return loadDocumentIndex();
+    return loadPageIndex();
   }
 
   const parsed = parseStoredState(raw, fallbackSheetStyle, labels);
 
   if (!parsed) {
     window.localStorage.removeItem(STORAGE_KEY);
-    return loadDocumentIndex();
+    return loadPageIndex();
   }
 
-  const meta = createDocument(parsed.title || labels.title, parsed);
+  const meta = createPage(parsed.title || labels.title, parsed);
   window.localStorage.removeItem(STORAGE_KEY);
 
-  const index = loadDocumentIndex();
-  index.activeDocumentId = meta.id;
-  saveDocumentIndex(index);
+  const index = loadPageIndex();
+  index.activePageId = meta.id;
+  savePageIndex(index);
 
   return index;
 }
@@ -229,7 +202,7 @@ export function migrateFromLegacyStorage(
 // File export / import
 // ---------------------------------------------------------------------------
 
-export function exportDocumentToFile(meta: DocumentMeta, state: WriterState): void {
+export function exportPageToFile(meta: PageMeta, state: WriterState): void {
   const file: DysmathsFile = {
     format: "dysmaths",
     version: DYSMATHS_FILE_VERSION,

--- a/components/math-workbook/document-store.ts
+++ b/components/math-workbook/document-store.ts
@@ -1,0 +1,277 @@
+import { saveAs } from "file-saver";
+import {
+  type DefaultDocumentLabels,
+  type SheetStyle,
+  type WriterState,
+  STORAGE_KEY,
+  WRITER_STATE_SCHEMA_VERSION,
+  cloneWriterState,
+  parseStoredState,
+  safeFileName
+} from "./shared";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DocumentMeta = {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DocumentIndex = {
+  version: number;
+  activeDocumentId: string | null;
+  documents: DocumentMeta[];
+};
+
+export type DysmathsFile = {
+  format: "dysmaths";
+  version: number;
+  schemaVersion: number;
+  exportedAt: string;
+  name: string;
+  state: WriterState;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const DOCUMENT_INDEX_KEY = "dysmaths-documents-v1";
+const DOCUMENT_KEY_PREFIX = "dysmaths-doc-";
+const DOCUMENT_INDEX_VERSION = 1;
+const DYSMATHS_FILE_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getDocumentStorageKey(docId: string): string {
+  return `${DOCUMENT_KEY_PREFIX}${docId}`;
+}
+
+function createEmptyIndex(): DocumentIndex {
+  return { version: DOCUMENT_INDEX_VERSION, activeDocumentId: null, documents: [] };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Index operations
+// ---------------------------------------------------------------------------
+
+export function loadDocumentIndex(): DocumentIndex {
+  try {
+    const raw = window.localStorage.getItem(DOCUMENT_INDEX_KEY);
+
+    if (!raw) {
+      return createEmptyIndex();
+    }
+
+    const parsed = JSON.parse(raw) as DocumentIndex;
+
+    if (!parsed || !Array.isArray(parsed.documents)) {
+      return createEmptyIndex();
+    }
+
+    return {
+      version: DOCUMENT_INDEX_VERSION,
+      activeDocumentId: typeof parsed.activeDocumentId === "string" ? parsed.activeDocumentId : null,
+      documents: parsed.documents.filter(
+        (d) =>
+          d &&
+          typeof d.id === "string" &&
+          typeof d.name === "string" &&
+          typeof d.createdAt === "string" &&
+          typeof d.updatedAt === "string"
+      )
+    };
+  } catch {
+    return createEmptyIndex();
+  }
+}
+
+export function saveDocumentIndex(index: DocumentIndex): void {
+  window.localStorage.setItem(DOCUMENT_INDEX_KEY, JSON.stringify(index));
+}
+
+// ---------------------------------------------------------------------------
+// Document state operations
+// ---------------------------------------------------------------------------
+
+export function loadDocumentState(
+  docId: string,
+  fallbackSheetStyle: SheetStyle,
+  labels: DefaultDocumentLabels
+): WriterState | null {
+  const raw = window.localStorage.getItem(getDocumentStorageKey(docId));
+
+  if (!raw) {
+    return null;
+  }
+
+  return parseStoredState(raw, fallbackSheetStyle, labels);
+}
+
+export function saveDocumentState(docId: string, state: WriterState): void {
+  window.localStorage.setItem(getDocumentStorageKey(docId), JSON.stringify(state));
+
+  // Update the updatedAt timestamp in the index
+  const index = loadDocumentIndex();
+  const entry = index.documents.find((d) => d.id === docId);
+
+  if (entry) {
+    entry.updatedAt = nowIso();
+    saveDocumentIndex(index);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CRUD operations
+// ---------------------------------------------------------------------------
+
+export function createDocument(name: string, state: WriterState): DocumentMeta {
+  const now = nowIso();
+  const meta: DocumentMeta = {
+    id: crypto.randomUUID(),
+    name: name || "Untitled",
+    createdAt: now,
+    updatedAt: now
+  };
+
+  const index = loadDocumentIndex();
+  index.documents.push(meta);
+  index.activeDocumentId = meta.id;
+  saveDocumentIndex(index);
+  window.localStorage.setItem(getDocumentStorageKey(meta.id), JSON.stringify(state));
+
+  return meta;
+}
+
+export function renameDocument(docId: string, name: string): void {
+  const index = loadDocumentIndex();
+  const entry = index.documents.find((d) => d.id === docId);
+
+  if (entry) {
+    entry.name = name;
+    entry.updatedAt = nowIso();
+    saveDocumentIndex(index);
+  }
+}
+
+export function deleteDocument(docId: string): void {
+  const index = loadDocumentIndex();
+  index.documents = index.documents.filter((d) => d.id !== docId);
+
+  if (index.activeDocumentId === docId) {
+    index.activeDocumentId = index.documents[0]?.id ?? null;
+  }
+
+  saveDocumentIndex(index);
+  window.localStorage.removeItem(getDocumentStorageKey(docId));
+}
+
+export function duplicateDocument(
+  docId: string,
+  newName: string,
+  fallbackSheetStyle: SheetStyle,
+  labels: DefaultDocumentLabels
+): DocumentMeta | null {
+  const state = loadDocumentState(docId, fallbackSheetStyle, labels);
+
+  if (!state) {
+    return null;
+  }
+
+  const cloned = cloneWriterState(state);
+  cloned.title = newName;
+
+  return createDocument(newName, cloned);
+}
+
+// ---------------------------------------------------------------------------
+// Migration from legacy single-document storage
+// ---------------------------------------------------------------------------
+
+export function migrateFromLegacyStorage(
+  fallbackSheetStyle: SheetStyle,
+  labels: DefaultDocumentLabels
+): DocumentIndex {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return loadDocumentIndex();
+  }
+
+  const parsed = parseStoredState(raw, fallbackSheetStyle, labels);
+
+  if (!parsed) {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return loadDocumentIndex();
+  }
+
+  const meta = createDocument(parsed.title || labels.title, parsed);
+  window.localStorage.removeItem(STORAGE_KEY);
+
+  const index = loadDocumentIndex();
+  index.activeDocumentId = meta.id;
+  saveDocumentIndex(index);
+
+  return index;
+}
+
+// ---------------------------------------------------------------------------
+// File export / import
+// ---------------------------------------------------------------------------
+
+export function exportDocumentToFile(meta: DocumentMeta, state: WriterState): void {
+  const file: DysmathsFile = {
+    format: "dysmaths",
+    version: DYSMATHS_FILE_VERSION,
+    schemaVersion: WRITER_STATE_SCHEMA_VERSION,
+    exportedAt: nowIso(),
+    name: meta.name,
+    state
+  };
+
+  const blob = new Blob([JSON.stringify(file, null, 2)], { type: "application/json" });
+  const fileName = `${safeFileName(meta.name) || "dysmaths"}.dysmaths`;
+  saveAs(blob, fileName);
+}
+
+export function parseImportedFile(
+  raw: string,
+  fallbackSheetStyle: SheetStyle,
+  labels: DefaultDocumentLabels
+): { name: string; state: WriterState } | null {
+  try {
+    const parsed = JSON.parse(raw) as DysmathsFile;
+
+    // Accept both wrapped .dysmaths files and raw WriterState JSON
+    if (parsed && parsed.format === "dysmaths" && parsed.state) {
+      const state = parseStoredState(JSON.stringify(parsed.state), fallbackSheetStyle, labels);
+
+      if (!state) {
+        return null;
+      }
+
+      return { name: parsed.name || state.title || "Imported", state };
+    }
+
+    // Fallback: try parsing as raw WriterState
+    const state = parseStoredState(raw, fallbackSheetStyle, labels);
+
+    if (!state) {
+      return null;
+    }
+
+    return { name: state.title || "Imported", state };
+  } catch {
+    return null;
+  }
+}

--- a/components/math-workbook/presentational.tsx
+++ b/components/math-workbook/presentational.tsx
@@ -52,6 +52,7 @@ import {
   type UserProfile,
   type WorkbookTranslator
 } from "@/components/math-workbook/shared";
+import type {DocumentMeta} from "@/components/math-workbook/document-store";
 
 type WorkbookSidebarProps = {
   t: WorkbookTranslator;
@@ -717,14 +718,21 @@ type WorkbookActionBarProps = {
   sheetStyleOptions: SheetStyleOption[];
   profiles: UserProfile[];
   activeProfileId: string | null;
+  documents: DocumentMeta[];
+  activeDocumentId: string | null;
   onOpenTools: () => void;
   onUndo: () => void;
   onRedo: () => void;
   onExportPdf: () => void;
   onExportPng: () => void;
   onPrint: () => void;
+  onExportDocumentFile: () => void;
   onSheetStyleChange: (sheetStyle: SheetStyle) => void;
   onResetDocument: () => void;
+  onSwitchDocument: (docId: string) => void;
+  onNewDocument: () => void;
+  onImportDocument: () => void;
+  onOpenDocumentManager: () => void;
   onProfileChange: (profileId: string | null) => void;
   onSetProfileEditMode: (mode: "create" | "edit" | null) => void;
 };
@@ -743,8 +751,15 @@ export function WorkbookActionBar({
   onExportPdf,
   onExportPng,
   onPrint,
+  onExportDocumentFile,
   onSheetStyleChange,
   onResetDocument,
+  documents,
+  activeDocumentId,
+  onSwitchDocument,
+  onNewDocument,
+  onImportDocument,
+  onOpenDocumentManager,
   profiles,
   activeProfileId,
   onProfileChange,
@@ -760,6 +775,19 @@ export function WorkbookActionBar({
       onProfileChange(value || null);
     }
   }
+
+  function handleDocumentSwitcherChange(value: string) {
+    if (value === "__new__") {
+      onNewDocument();
+    } else if (value === "__import__") {
+      onImportDocument();
+    } else if (value === "__manage__") {
+      onOpenDocumentManager();
+    } else {
+      onSwitchDocument(value);
+    }
+  }
+
   return (
     <div className="sheet-action-bar">
       <div className="sheet-action-group">
@@ -798,6 +826,14 @@ export function WorkbookActionBar({
         <button type="button" className="toolbar-action ghost" onClick={onPrint} disabled={isExporting !== null}>
           {isExporting === "print" ? t("toolbar.preparingPrint") : t("toolbar.print")}
         </button>
+        <button type="button" className="toolbar-action ghost" onClick={onExportDocumentFile} title={t("documentManager.exportFile")}>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+          .dysmaths
+        </button>
         <label className="sheet-style-picker sheet-style-picker-toolbar">
           <select className="sheet-style-select" value={sheetStyle} onChange={(event) => onSheetStyleChange(event.target.value as SheetStyle)} aria-label={t("toolbar.sheetStyle")} data-testid="sheet-style-select">
             {sheetStyleOptions.map((option) => (
@@ -810,6 +846,30 @@ export function WorkbookActionBar({
         <button type="button" className="toolbar-action ghost" onClick={onResetDocument}>
           {t("toolbar.newDocument")}
         </button>
+        <div className="document-switcher" title={t("documentManager.title")}>
+          <select
+            className="document-switcher-select"
+            value={activeDocumentId ?? ""}
+            onChange={(event) => handleDocumentSwitcherChange(event.target.value)}
+            aria-label={t("documentManager.title")}
+          >
+            {documents.map((doc) => (
+              <option key={doc.id} value={doc.id}>
+                {doc.name.length > 30 ? `${doc.name.slice(0, 30)}…` : doc.name}
+              </option>
+            ))}
+            <option disabled>──────────</option>
+            <option value="__new__">+ {t("toolbar.newDocument")}</option>
+            <option value="__import__">{t("documentManager.importFile")}</option>
+            <option value="__manage__">{t("documentManager.manageDocuments")}</option>
+          </select>
+          <span className="document-switcher-badge" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" />
+              <polyline points="14 2 14 8 20 8" />
+            </svg>
+          </span>
+        </div>
         <div className="profile-switcher" title={t("profile.switcherHint")}>
           <select
             className="profile-switcher-select"
@@ -1679,6 +1739,171 @@ export function ProfileModal({ t, mode, profile, sheetStyleOptions, onSave, onCl
             <input type="checkbox" checked={highlightOnHover} onChange={(event) => setHighlightOnHover(event.target.checked)} />
             <span>{t("profile.highlightOnHover")}</span>
           </label>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Document Manager Modal
+// ---------------------------------------------------------------------------
+
+type DocumentManagerModalProps = {
+  t: WorkbookTranslator;
+  documents: DocumentMeta[];
+  activeDocumentId: string | null;
+  onSwitchDocument: (docId: string) => void;
+  onRenameDocument: (docId: string, name: string) => void;
+  onDuplicateDocument: (docId: string) => void;
+  onDeleteDocument: (docId: string) => void;
+  onExportDocument: (docId: string) => void;
+  onImportDocument: () => void;
+  onClose: () => void;
+};
+
+export function DocumentManagerModal({
+  t,
+  documents,
+  activeDocumentId,
+  onSwitchDocument,
+  onRenameDocument,
+  onDuplicateDocument,
+  onDeleteDocument,
+  onExportDocument,
+  onImportDocument,
+  onClose
+}: DocumentManagerModalProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+
+  function startRename(doc: DocumentMeta) {
+    setEditingId(doc.id);
+    setEditingName(doc.name);
+  }
+
+  function commitRename() {
+    if (editingId && editingName.trim()) {
+      onRenameDocument(editingId, editingName.trim());
+    }
+
+    setEditingId(null);
+    setEditingName("");
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section className="block-modal document-manager-modal" role="dialog" aria-modal="true" aria-labelledby="doc-manager-title" onClick={(event) => event.stopPropagation()}>
+        <div className="block-modal-head">
+          <div>
+            <h2 id="doc-manager-title">{t("documentManager.title")}</h2>
+          </div>
+          <div className="card-actions">
+            <button type="button" className="small-action" onClick={onImportDocument}>
+              {t("documentManager.importFile")}
+            </button>
+            <button type="button" className="small-action" onClick={onClose}>
+              {t("documentManager.close")}
+            </button>
+          </div>
+        </div>
+        <div className="document-manager-list">
+          {documents.map((doc) => (
+            <div
+              key={doc.id}
+              className={`document-manager-item${doc.id === activeDocumentId ? " document-manager-item-active" : ""}`}
+              onClick={() => { if (doc.id !== activeDocumentId) onSwitchDocument(doc.id); }}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => { if (event.key === "Enter" && doc.id !== activeDocumentId) onSwitchDocument(doc.id); }}
+            >
+              <div className="document-manager-item-info">
+                {editingId === doc.id ? (
+                  <input
+                    className="document-manager-rename-input"
+                    type="text"
+                    value={editingName}
+                    onChange={(event) => setEditingName(event.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(event) => { if (event.key === "Enter") commitRename(); if (event.key === "Escape") setEditingId(null); }}
+                    onClick={(event) => event.stopPropagation()}
+                    autoFocus
+                  />
+                ) : (
+                  <span className="document-manager-item-name">{doc.name}</span>
+                )}
+                <span className="document-manager-item-date">
+                  {t("documentManager.modified")}: {new Date(doc.updatedAt).toLocaleDateString()}
+                </span>
+              </div>
+              <div className="document-manager-actions" onClick={(event) => event.stopPropagation()}>
+                <button type="button" className="small-action" onClick={() => startRename(doc)} title={t("documentManager.rename")}>
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+                  </svg>
+                </button>
+                <button type="button" className="small-action" onClick={() => onDuplicateDocument(doc.id)} title={t("documentManager.duplicate")}>
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+                  </svg>
+                </button>
+                <button type="button" className="small-action" onClick={() => onExportDocument(doc.id)} title={t("documentManager.exportFile")}>
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  className="small-action"
+                  onClick={() => onDeleteDocument(doc.id)}
+                  title={t("documentManager.delete")}
+                  disabled={documents.length <= 1}
+                >
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="3 6 5 6 21 6" />
+                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Confirm Delete Document Modal
+// ---------------------------------------------------------------------------
+
+type ConfirmDeleteDocumentModalProps = {
+  t: WorkbookTranslator;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export function ConfirmDeleteDocumentModal({t, onClose, onConfirm}: ConfirmDeleteDocumentModalProps) {
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <section className="block-modal" role="dialog" aria-modal="true" aria-labelledby="delete-doc-modal-title" onClick={(event) => event.stopPropagation()}>
+        <div className="block-modal-head">
+          <div>
+            <p className="card-kind">{t("modal.confirmation")}</p>
+            <h2 id="delete-doc-modal-title">{t("documentManager.deleteConfirm")}</h2>
+            <p className="toolbar-helper">{t("documentManager.deleteHelper")}</p>
+          </div>
+          <div className="card-actions">
+            <button type="button" className="small-action" onClick={onClose}>
+              {t("modal.cancel")}
+            </button>
+            <button type="button" className="small-action primary-inline-action" onClick={onConfirm}>
+              {t("documentManager.delete")}
+            </button>
+          </div>
         </div>
       </section>
     </div>

--- a/components/math-workbook/presentational.tsx
+++ b/components/math-workbook/presentational.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import {createPortal} from "react-dom";
 import type {CSSProperties as ReactCSSProperties, DragEvent as ReactDragEvent, MouseEvent as ReactMouseEvent, ReactNode, RefObject} from "react";
 import {localeLabels, type AppLocale} from "@/i18n/routing";
@@ -52,7 +52,7 @@ import {
   type UserProfile,
   type WorkbookTranslator
 } from "@/components/math-workbook/shared";
-import type {DocumentMeta} from "@/components/math-workbook/document-store";
+import type {PageMeta} from "@/components/math-workbook/document-store";
 
 type WorkbookSidebarProps = {
   t: WorkbookTranslator;
@@ -718,21 +718,21 @@ type WorkbookActionBarProps = {
   sheetStyleOptions: SheetStyleOption[];
   profiles: UserProfile[];
   activeProfileId: string | null;
-  documents: DocumentMeta[];
-  activeDocumentId: string | null;
+  pages: PageMeta[];
+  activePageId: string | null;
   onOpenTools: () => void;
   onUndo: () => void;
   onRedo: () => void;
   onExportPdf: () => void;
   onExportPng: () => void;
   onPrint: () => void;
-  onExportDocumentFile: () => void;
   onSheetStyleChange: (sheetStyle: SheetStyle) => void;
-  onResetDocument: () => void;
-  onSwitchDocument: (docId: string) => void;
-  onNewDocument: () => void;
-  onImportDocument: () => void;
-  onOpenDocumentManager: () => void;
+  onNewPage: () => void;
+  onSwitchPage: (pageId: string) => void;
+  onDeletePage: (pageId: string) => void;
+  onDeleteAllPages: () => void;
+  onExportFile: () => void;
+  onImportFile: () => void;
   onProfileChange: (profileId: string | null) => void;
   onSetProfileEditMode: (mode: "create" | "edit" | null) => void;
 };
@@ -751,21 +751,42 @@ export function WorkbookActionBar({
   onExportPdf,
   onExportPng,
   onPrint,
-  onExportDocumentFile,
   onSheetStyleChange,
-  onResetDocument,
-  documents,
-  activeDocumentId,
-  onSwitchDocument,
-  onNewDocument,
-  onImportDocument,
-  onOpenDocumentManager,
+  pages,
+  activePageId,
+  onNewPage,
+  onSwitchPage,
+  onDeletePage,
+  onDeleteAllPages,
+  onExportFile,
+  onImportFile,
   profiles,
   activeProfileId,
   onProfileChange,
   onSetProfileEditMode
 }: WorkbookActionBarProps) {
+  const [fileMenuOpen, setFileMenuOpen] = useState(false);
+  const [pageMenuOpen, setPageMenuOpen] = useState(false);
+  const pageMenuRef = useRef<HTMLDivElement>(null);
+  const fileMenuRef = useRef<HTMLDivElement>(null);
   const activeProfile = profiles.find((p) => p.id === activeProfileId);
+
+  useEffect(() => {
+    if (!fileMenuOpen && !pageMenuOpen) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (fileMenuOpen && fileMenuRef.current && !fileMenuRef.current.contains(target)) {
+        setFileMenuOpen(false);
+      }
+      if (pageMenuOpen && pageMenuRef.current && !pageMenuRef.current.contains(target)) {
+        setPageMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [fileMenuOpen, pageMenuOpen]);
   const initials = activeProfile ? `${activeProfile.firstName.charAt(0)}${activeProfile.lastName.charAt(0)}`.toUpperCase() : null;
 
   function handleSwitcherChange(value: string) {
@@ -773,18 +794,6 @@ export function WorkbookActionBar({
       onSetProfileEditMode("create");
     } else {
       onProfileChange(value || null);
-    }
-  }
-
-  function handleDocumentSwitcherChange(value: string) {
-    if (value === "__new__") {
-      onNewDocument();
-    } else if (value === "__import__") {
-      onImportDocument();
-    } else if (value === "__manage__") {
-      onOpenDocumentManager();
-    } else {
-      onSwitchDocument(value);
     }
   }
 
@@ -826,14 +835,6 @@ export function WorkbookActionBar({
         <button type="button" className="toolbar-action ghost" onClick={onPrint} disabled={isExporting !== null}>
           {isExporting === "print" ? t("toolbar.preparingPrint") : t("toolbar.print")}
         </button>
-        <button type="button" className="toolbar-action ghost" onClick={onExportDocumentFile} title={t("documentManager.exportFile")}>
-          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-            <polyline points="7 10 12 15 17 10" />
-            <line x1="12" y1="15" x2="12" y2="3" />
-          </svg>
-          .dysmaths
-        </button>
         <label className="sheet-style-picker sheet-style-picker-toolbar">
           <select className="sheet-style-select" value={sheetStyle} onChange={(event) => onSheetStyleChange(event.target.value as SheetStyle)} aria-label={t("toolbar.sheetStyle")} data-testid="sheet-style-select">
             {sheetStyleOptions.map((option) => (
@@ -843,32 +844,88 @@ export function WorkbookActionBar({
             ))}
           </select>
         </label>
-        <button type="button" className="toolbar-action ghost" onClick={onResetDocument}>
-          {t("toolbar.newDocument")}
+        <button type="button" className="toolbar-action ghost" onClick={onNewPage}>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          {t("pages.newPage")}
         </button>
-        <div className="document-switcher" title={t("documentManager.title")}>
-          <select
-            className="document-switcher-select"
-            value={activeDocumentId ?? ""}
-            onChange={(event) => handleDocumentSwitcherChange(event.target.value)}
-            aria-label={t("documentManager.title")}
-          >
-            {documents.map((doc) => (
-              <option key={doc.id} value={doc.id}>
-                {doc.name.length > 30 ? `${doc.name.slice(0, 30)}…` : doc.name}
-              </option>
-            ))}
-            <option disabled>──────────</option>
-            <option value="__new__">+ {t("toolbar.newDocument")}</option>
-            <option value="__import__">{t("documentManager.importFile")}</option>
-            <option value="__manage__">{t("documentManager.manageDocuments")}</option>
-          </select>
-          <span className="document-switcher-badge" aria-hidden="true">
-            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        {pages.length > 1 ? (
+          <div className="page-navigator" ref={pageMenuRef} aria-label={t("pages.page")}>
+            <button type="button" className="page-nav-toggle" onClick={() => setPageMenuOpen(!pageMenuOpen)}>
+              {t("pages.page")} {pages.findIndex((p) => p.id === activePageId) + 1}/{pages.length}
+              <svg viewBox="0 0 10 6" width="10" height="6" aria-hidden="true">
+                <path d="M0 0l5 6 5-6z" fill="currentColor" opacity="0.5" />
+              </svg>
+            </button>
+            {pageMenuOpen ? (
+              <div className="page-menu-dropdown" role="menu">
+                  {pages.map((page, index) => (
+                    <button
+                      key={page.id}
+                      type="button"
+                      className={`file-menu-item${page.id === activePageId ? " page-menu-item-active" : ""}`}
+                      role="menuitem"
+                      onClick={() => { onSwitchPage(page.id); setPageMenuOpen(false); }}
+                    >
+                      {t("pages.page")} {index + 1}
+                    </button>
+                  ))}
+                </div>
+            ) : null}
+            <button
+              type="button"
+              className="page-nav-delete"
+              onClick={() => onDeletePage(activePageId!)}
+              title={t("pages.deletePage")}
+            >
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        ) : null}
+        <div className="file-menu-wrapper" ref={fileMenuRef}>
+          <button type="button" className="toolbar-action ghost file-menu-toggle" onClick={() => setFileMenuOpen(!fileMenuOpen)} title={t("pages.fileMenu")}>
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" />
               <polyline points="14 2 14 8 20 8" />
             </svg>
-          </span>
+          </button>
+          {fileMenuOpen ? (
+              <div className="file-menu-dropdown" role="menu">
+                <button type="button" className="file-menu-item" role="menuitem" onClick={() => { onExportFile(); setFileMenuOpen(false); }}>
+                  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                  {t("pages.exportFile")}
+                </button>
+                <button type="button" className="file-menu-item" role="menuitem" onClick={() => { onImportFile(); setFileMenuOpen(false); }}>
+                  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                  </svg>
+                  {t("pages.importFile")}
+                </button>
+                {pages.length > 1 ? (
+                  <>
+                    <hr className="file-menu-separator" />
+                    <button type="button" className="file-menu-item file-menu-item-danger" role="menuitem" onClick={() => { onDeleteAllPages(); setFileMenuOpen(false); }}>
+                      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="3 6 5 6 21 6" />
+                        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                      </svg>
+                      {t("pages.deleteAll")}
+                    </button>
+                  </>
+                ) : null}
+              </div>
+          ) : null}
         </div>
         <div className="profile-switcher" title={t("profile.switcherHint")}>
           <select
@@ -1745,167 +1802,3 @@ export function ProfileModal({ t, mode, profile, sheetStyleOptions, onSave, onCl
   );
 }
 
-// ---------------------------------------------------------------------------
-// Document Manager Modal
-// ---------------------------------------------------------------------------
-
-type DocumentManagerModalProps = {
-  t: WorkbookTranslator;
-  documents: DocumentMeta[];
-  activeDocumentId: string | null;
-  onSwitchDocument: (docId: string) => void;
-  onRenameDocument: (docId: string, name: string) => void;
-  onDuplicateDocument: (docId: string) => void;
-  onDeleteDocument: (docId: string) => void;
-  onExportDocument: (docId: string) => void;
-  onImportDocument: () => void;
-  onClose: () => void;
-};
-
-export function DocumentManagerModal({
-  t,
-  documents,
-  activeDocumentId,
-  onSwitchDocument,
-  onRenameDocument,
-  onDuplicateDocument,
-  onDeleteDocument,
-  onExportDocument,
-  onImportDocument,
-  onClose
-}: DocumentManagerModalProps) {
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingName, setEditingName] = useState("");
-
-  function startRename(doc: DocumentMeta) {
-    setEditingId(doc.id);
-    setEditingName(doc.name);
-  }
-
-  function commitRename() {
-    if (editingId && editingName.trim()) {
-      onRenameDocument(editingId, editingName.trim());
-    }
-
-    setEditingId(null);
-    setEditingName("");
-  }
-
-  return (
-    <div className="modal-backdrop" role="presentation" onClick={onClose}>
-      <section className="block-modal document-manager-modal" role="dialog" aria-modal="true" aria-labelledby="doc-manager-title" onClick={(event) => event.stopPropagation()}>
-        <div className="block-modal-head">
-          <div>
-            <h2 id="doc-manager-title">{t("documentManager.title")}</h2>
-          </div>
-          <div className="card-actions">
-            <button type="button" className="small-action" onClick={onImportDocument}>
-              {t("documentManager.importFile")}
-            </button>
-            <button type="button" className="small-action" onClick={onClose}>
-              {t("documentManager.close")}
-            </button>
-          </div>
-        </div>
-        <div className="document-manager-list">
-          {documents.map((doc) => (
-            <div
-              key={doc.id}
-              className={`document-manager-item${doc.id === activeDocumentId ? " document-manager-item-active" : ""}`}
-              onClick={() => { if (doc.id !== activeDocumentId) onSwitchDocument(doc.id); }}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(event) => { if (event.key === "Enter" && doc.id !== activeDocumentId) onSwitchDocument(doc.id); }}
-            >
-              <div className="document-manager-item-info">
-                {editingId === doc.id ? (
-                  <input
-                    className="document-manager-rename-input"
-                    type="text"
-                    value={editingName}
-                    onChange={(event) => setEditingName(event.target.value)}
-                    onBlur={commitRename}
-                    onKeyDown={(event) => { if (event.key === "Enter") commitRename(); if (event.key === "Escape") setEditingId(null); }}
-                    onClick={(event) => event.stopPropagation()}
-                    autoFocus
-                  />
-                ) : (
-                  <span className="document-manager-item-name">{doc.name}</span>
-                )}
-                <span className="document-manager-item-date">
-                  {t("documentManager.modified")}: {new Date(doc.updatedAt).toLocaleDateString()}
-                </span>
-              </div>
-              <div className="document-manager-actions" onClick={(event) => event.stopPropagation()}>
-                <button type="button" className="small-action" onClick={() => startRename(doc)} title={t("documentManager.rename")}>
-                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-                  </svg>
-                </button>
-                <button type="button" className="small-action" onClick={() => onDuplicateDocument(doc.id)} title={t("documentManager.duplicate")}>
-                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-                    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-                  </svg>
-                </button>
-                <button type="button" className="small-action" onClick={() => onExportDocument(doc.id)} title={t("documentManager.exportFile")}>
-                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                    <polyline points="7 10 12 15 17 10" />
-                    <line x1="12" y1="15" x2="12" y2="3" />
-                  </svg>
-                </button>
-                <button
-                  type="button"
-                  className="small-action"
-                  onClick={() => onDeleteDocument(doc.id)}
-                  title={t("documentManager.delete")}
-                  disabled={documents.length <= 1}
-                >
-                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <polyline points="3 6 5 6 21 6" />
-                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Confirm Delete Document Modal
-// ---------------------------------------------------------------------------
-
-type ConfirmDeleteDocumentModalProps = {
-  t: WorkbookTranslator;
-  onClose: () => void;
-  onConfirm: () => void;
-};
-
-export function ConfirmDeleteDocumentModal({t, onClose, onConfirm}: ConfirmDeleteDocumentModalProps) {
-  return (
-    <div className="modal-backdrop" role="presentation" onClick={onClose}>
-      <section className="block-modal" role="dialog" aria-modal="true" aria-labelledby="delete-doc-modal-title" onClick={(event) => event.stopPropagation()}>
-        <div className="block-modal-head">
-          <div>
-            <p className="card-kind">{t("modal.confirmation")}</p>
-            <h2 id="delete-doc-modal-title">{t("documentManager.deleteConfirm")}</h2>
-            <p className="toolbar-helper">{t("documentManager.deleteHelper")}</p>
-          </div>
-          <div className="card-actions">
-            <button type="button" className="small-action" onClick={onClose}>
-              {t("modal.cancel")}
-            </button>
-            <button type="button" className="small-action primary-inline-action" onClick={onConfirm}>
-              {t("documentManager.delete")}
-            </button>
-          </div>
-        </div>
-      </section>
-    </div>
-  );
-}

--- a/components/math-workbook/shared.tsx
+++ b/components/math-workbook/shared.tsx
@@ -498,6 +498,7 @@ export type SymbolResizeState = {
   startSize: number;
 };
 
+/** @deprecated Use document-store.ts for multi-document storage. Kept for migration. */
 export const STORAGE_KEY = "maths-facile-free-layout-v1";
 export const PROFILE_STORAGE_KEY = "dysmaths-profiles-v1";
 export const WRITER_STATE_SCHEMA_VERSION = 2;

--- a/messages/index.ts
+++ b/messages/index.ts
@@ -65,22 +65,18 @@ type Messages = {
       install: string;
       installHelp: string;
     };
-    documentManager: {
-      title: string;
-      rename: string;
-      duplicate: string;
-      delete: string;
-      deleteConfirm: string;
-      deleteHelper: string;
+    pages: {
+      newPage: string;
+      deletePage: string;
+      deletePageConfirm: string;
+      deleteAll: string;
+      deleteAllConfirm: string;
+      page: string;
       exportFile: string;
       importFile: string;
-      close: string;
-      untitled: string;
-      duplicateSuffix: string;
       importError: string;
-      created: string;
-      modified: string;
-      manageDocuments: string;
+      untitled: string;
+      fileMenu: string;
     };
     geometryHelper: {
       idle: string;
@@ -314,22 +310,18 @@ const en: Messages = {
       install: "Install",
       installHelp: "Use the install icon in the address bar or your browser menu to install the app on this device."
     },
-    documentManager: {
-      title: "My documents",
-      rename: "Rename",
-      duplicate: "Duplicate",
-      delete: "Delete",
-      deleteConfirm: "Delete this document?",
-      deleteHelper: "This document will be permanently deleted.",
+    pages: {
+      newPage: "New",
+      deletePage: "Delete",
+      deletePageConfirm: "Delete this page?",
+      deleteAll: "Delete all pages",
+      deleteAllConfirm: "Delete all pages and start fresh?",
+      page: "Page",
       exportFile: "Save as file",
       importFile: "Open a file",
-      close: "Close",
-      untitled: "Untitled document",
-      duplicateSuffix: " (copy)",
       importError: "Could not read this file.",
-      created: "Created",
-      modified: "Modified",
-      manageDocuments: "Manage documents"
+      untitled: "Untitled",
+      fileMenu: "File"
     },
     geometryHelper: {
       idle: "Draw precise figures while preserving the sheet scale for printing.",
@@ -572,22 +564,18 @@ const fr: Messages = {
       install: "Installer",
       installHelp: "Utilise l’icône d’installation dans la barre d’adresse ou le menu du navigateur pour installer l’app sur cet appareil."
     },
-    documentManager: {
-      title: "Mes documents",
-      rename: "Renommer",
-      duplicate: "Dupliquer",
-      delete: "Supprimer",
-      deleteConfirm: "Supprimer ce document ?",
-      deleteHelper: "Ce document sera supprimé définitivement.",
+    pages: {
+      newPage: "Nouveau",
+      deletePage: "Supprimer",
+      deletePageConfirm: "Supprimer cette page ?",
+      deleteAll: "Supprimer toutes les pages",
+      deleteAllConfirm: "Supprimer toutes les pages et recommencer ?",
+      page: "Page",
       exportFile: "Enregistrer en fichier",
       importFile: "Ouvrir un fichier",
-      close: "Fermer",
-      untitled: "Document sans titre",
-      duplicateSuffix: " (copie)",
       importError: "Impossible de lire ce fichier.",
-      created: "Créé le",
-      modified: "Modifié le",
-      manageDocuments: "Gérer les documents"
+      untitled: "Sans titre",
+      fileMenu: "Fichier"
     },
     geometryHelper: {
       idle: "Trace des figures précises en gardant l’échelle de la feuille pour l’impression.",
@@ -830,22 +818,18 @@ const es: Messages = {
       install: "Instalar",
       installHelp: "Usa el icono de instalación de la barra de direcciones o el menú del navegador para instalar la app en este dispositivo."
     },
-    documentManager: {
-      title: "Mis documentos",
-      rename: "Renombrar",
-      duplicate: "Duplicar",
-      delete: "Eliminar",
-      deleteConfirm: "¿Eliminar este documento?",
-      deleteHelper: "Este documento se eliminará permanentemente.",
+    pages: {
+      newPage: "Nuevo",
+      deletePage: "Eliminar",
+      deletePageConfirm: "¿Eliminar esta página?",
+      deleteAll: "Eliminar todas las páginas",
+      deleteAllConfirm: "¿Eliminar todas las páginas y empezar de nuevo?",
+      page: "Página",
       exportFile: "Guardar como archivo",
       importFile: "Abrir un archivo",
-      close: "Cerrar",
-      untitled: "Documento sin título",
-      duplicateSuffix: " (copia)",
       importError: "No se pudo leer este archivo.",
-      created: "Creado",
-      modified: "Modificado",
-      manageDocuments: "Gestionar documentos"
+      untitled: "Sin título",
+      fileMenu: "Archivo"
     },
     geometryHelper: {
       idle: "Traza figuras precisas manteniendo la escala de la hoja para la impresión.",

--- a/messages/index.ts
+++ b/messages/index.ts
@@ -65,6 +65,23 @@ type Messages = {
       install: string;
       installHelp: string;
     };
+    documentManager: {
+      title: string;
+      rename: string;
+      duplicate: string;
+      delete: string;
+      deleteConfirm: string;
+      deleteHelper: string;
+      exportFile: string;
+      importFile: string;
+      close: string;
+      untitled: string;
+      duplicateSuffix: string;
+      importError: string;
+      created: string;
+      modified: string;
+      manageDocuments: string;
+    };
     geometryHelper: {
       idle: string;
       protractorFirstSide: string;
@@ -296,6 +313,23 @@ const en: Messages = {
       settings: "Settings",
       install: "Install",
       installHelp: "Use the install icon in the address bar or your browser menu to install the app on this device."
+    },
+    documentManager: {
+      title: "My documents",
+      rename: "Rename",
+      duplicate: "Duplicate",
+      delete: "Delete",
+      deleteConfirm: "Delete this document?",
+      deleteHelper: "This document will be permanently deleted.",
+      exportFile: "Save as file",
+      importFile: "Open a file",
+      close: "Close",
+      untitled: "Untitled document",
+      duplicateSuffix: " (copy)",
+      importError: "Could not read this file.",
+      created: "Created",
+      modified: "Modified",
+      manageDocuments: "Manage documents"
     },
     geometryHelper: {
       idle: "Draw precise figures while preserving the sheet scale for printing.",
@@ -538,6 +572,23 @@ const fr: Messages = {
       install: "Installer",
       installHelp: "Utilise l’icône d’installation dans la barre d’adresse ou le menu du navigateur pour installer l’app sur cet appareil."
     },
+    documentManager: {
+      title: "Mes documents",
+      rename: "Renommer",
+      duplicate: "Dupliquer",
+      delete: "Supprimer",
+      deleteConfirm: "Supprimer ce document ?",
+      deleteHelper: "Ce document sera supprimé définitivement.",
+      exportFile: "Enregistrer en fichier",
+      importFile: "Ouvrir un fichier",
+      close: "Fermer",
+      untitled: "Document sans titre",
+      duplicateSuffix: " (copie)",
+      importError: "Impossible de lire ce fichier.",
+      created: "Créé le",
+      modified: "Modifié le",
+      manageDocuments: "Gérer les documents"
+    },
     geometryHelper: {
       idle: "Trace des figures précises en gardant l’échelle de la feuille pour l’impression.",
       protractorFirstSide: "Clique un point sur le premier côté de l’angle.",
@@ -778,6 +829,23 @@ const es: Messages = {
       settings: "Ajustes",
       install: "Instalar",
       installHelp: "Usa el icono de instalación de la barra de direcciones o el menú del navegador para instalar la app en este dispositivo."
+    },
+    documentManager: {
+      title: "Mis documentos",
+      rename: "Renombrar",
+      duplicate: "Duplicar",
+      delete: "Eliminar",
+      deleteConfirm: "¿Eliminar este documento?",
+      deleteHelper: "Este documento se eliminará permanentemente.",
+      exportFile: "Guardar como archivo",
+      importFile: "Abrir un archivo",
+      close: "Cerrar",
+      untitled: "Documento sin título",
+      duplicateSuffix: " (copia)",
+      importError: "No se pudo leer este archivo.",
+      created: "Creado",
+      modified: "Modificado",
+      manageDocuments: "Gestionar documentos"
     },
     geometryHelper: {
       idle: "Traza figuras precisas manteniendo la escala de la hoja para la impresión.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,10 +31,74 @@
         "@types/node": "^22.13.10",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
+        "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.1",
-        "typescript": "^5.8.2"
+        "jsdom": "^29.0.1",
+        "typescript": "^5.8.2",
+        "vitest": "^4.1.2"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -67,6 +131,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -305,6 +370,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@cortex-js/compute-engine": {
       "version": "0.30.2",
       "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.30.2.tgz",
@@ -317,6 +395,148 @@
       "engines": {
         "node": ">=21.7.3",
         "npm": ">=10.5.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -507,6 +727,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1659,6 +1897,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
@@ -1960,6 +2208,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -1980,6 +2229,285 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1991,6 +2519,13 @@
       "version": "1.21.5",
       "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
       "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/core-darwin-arm64": {
@@ -2188,6 +2723,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2222,6 +2775,7 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2245,6 +2799,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2311,6 +2866,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2817,12 +3373,159 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3050,6 +3753,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3133,6 +3846,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3177,6 +3900,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3289,6 +4013,16 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3410,6 +4144,20 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3423,6 +4171,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3638,6 +4400,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
@@ -3756,6 +4531,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3845,6 +4627,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4017,6 +4800,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4266,6 +5050,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4274,6 +5068,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4781,6 +5585,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-to-image": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
@@ -5152,6 +5969,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5315,7 +6139,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5357,6 +6180,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -5528,7 +6402,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -5552,6 +6425,267 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -5600,6 +6734,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5622,6 +6766,13 @@
         "type": "individual",
         "url": "https://paypal.me/arnogourdol"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5751,6 +6902,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.4.11.tgz",
       "integrity": "sha512-IJRyXal45mIsshZI5XJne/intjusslUP1F+FHVBIyMGEqbYtIq1Irdx5vdWBBg58smviPDycmDeV6txsfkv1RQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.4.11",
         "@swc/helpers": "0.5.15",
@@ -5872,17 +7024,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
-      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -6050,6 +7191,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6137,6 +7289,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6164,6 +7329,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -6178,9 +7350,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6366,6 +7538,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6375,6 +7548,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6464,6 +7638,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -6524,6 +7708,40 @@
       "optional": true,
       "engines": {
         "node": ">= 0.8.15"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
       }
     },
     "node_modules/run-parallel": {
@@ -6632,6 +7850,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -6852,6 +8083,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6868,6 +8106,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -6877,6 +8122,13 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7096,6 +8348,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -7110,6 +8369,23 @@
       "optional": true,
       "dependencies": {
         "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -7129,6 +8405,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7140,6 +8446,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7284,6 +8616,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7333,6 +8666,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7455,6 +8798,278 @@
         "base64-arraybuffer": "^1.0.2"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7567,6 +9182,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7594,6 +9226,23 @@
       "bin": {
         "xml-js": "bin/cli.js"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -7639,6 +9288,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@lexical/rich-text": "^0.41.0",
         "@lexical/selection": "^0.41.0",
         "@lexical/utils": "^0.41.0",
+        "@swc/helpers": "^0.5.20",
         "docx": "^9.5.1",
         "file-saver": "^2.0.5",
         "html-to-image": "^1.11.13",
@@ -2691,9 +2692,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.20.tgz",
+      "integrity": "sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -7013,6 +7014,15 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -485,7 +484,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -534,7 +532,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2208,7 +2205,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -2775,7 +2771,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2799,7 +2794,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2866,7 +2860,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3525,7 +3518,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3900,7 +3892,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4627,7 +4618,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4800,7 +4790,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5266,7 +5255,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6139,6 +6127,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -6402,6 +6391,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -6902,7 +6892,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.4.11.tgz",
       "integrity": "sha512-IJRyXal45mIsshZI5XJne/intjusslUP1F+FHVBIyMGEqbYtIq1Irdx5vdWBBg58smviPDycmDeV6txsfkv1RQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.4.11",
         "@swc/helpers": "0.5.15",
@@ -7538,7 +7527,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7548,7 +7536,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8616,7 +8603,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8804,7 +8790,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9288,7 +9273,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "node scripts/run-next.cjs start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run",
     "test:e2e": "playwright test"
   },
   "dependencies": {
@@ -35,8 +36,11 @@
     "@types/node": "^22.13.10",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.1",
-    "typescript": "^5.8.2"
+    "jsdom": "^29.0.1",
+    "typescript": "^5.8.2",
+    "vitest": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@lexical/rich-text": "^0.41.0",
     "@lexical/selection": "^0.41.0",
     "@lexical/utils": "^0.41.0",
+    "@swc/helpers": "^0.5.20",
     "docx": "^9.5.1",
     "file-saver": "^2.0.5",
     "html-to-image": "^1.11.13",

--- a/tests/unit/document-store.test.ts
+++ b/tests/unit/document-store.test.ts
@@ -288,7 +288,7 @@ describe("document-store (pages)", () => {
       exportPageToFile(meta, state);
 
       expect(saveAs).toHaveBeenCalledTimes(1);
-      const [blob, fileName] = (saveAs as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [blob, fileName] = (saveAs as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(blob).toBeInstanceOf(Blob);
       expect(fileName).toBe("Export-Test.dysmaths");
     });

--- a/tests/unit/document-store.test.ts
+++ b/tests/unit/document-store.test.ts
@@ -1,19 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
-  type DocumentIndex,
-  type DocumentMeta,
+  type PageIndex,
+  type PageMeta,
   type DysmathsFile,
-  DOCUMENT_INDEX_KEY,
-  loadDocumentIndex,
-  saveDocumentIndex,
-  loadDocumentState,
-  saveDocumentState,
-  createDocument,
-  renameDocument,
-  deleteDocument,
-  duplicateDocument,
+  PAGE_INDEX_KEY,
+  loadPageIndex,
+  savePageIndex,
+  loadPageState,
+  savePageState,
+  createPage,
+  deletePage,
   migrateFromLegacyStorage,
-  exportDocumentToFile,
+  exportPageToFile,
   parseImportedFile
 } from "@/components/math-workbook/document-store";
 import {
@@ -67,7 +65,7 @@ function makeState(overrides?: Partial<WriterState>): WriterState {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("document-store", () => {
+describe("document-store (pages)", () => {
   let mockStorage: Storage;
 
   beforeEach(() => {
@@ -77,44 +75,44 @@ describe("document-store", () => {
   });
 
   // -----------------------------------------------------------------------
-  // loadDocumentIndex / saveDocumentIndex
+  // loadPageIndex / savePageIndex
   // -----------------------------------------------------------------------
 
-  describe("loadDocumentIndex", () => {
+  describe("loadPageIndex", () => {
     it("returns empty index when nothing stored", () => {
-      const index = loadDocumentIndex();
-      expect(index.documents).toEqual([]);
-      expect(index.activeDocumentId).toBeNull();
+      const index = loadPageIndex();
+      expect(index.pages).toEqual([]);
+      expect(index.activePageId).toBeNull();
       expect(index.version).toBe(1);
     });
 
     it("returns empty index when stored data is invalid", () => {
-      mockStorage.setItem(DOCUMENT_INDEX_KEY, "not json");
-      const index = loadDocumentIndex();
-      expect(index.documents).toEqual([]);
+      mockStorage.setItem(PAGE_INDEX_KEY, "not json");
+      const index = loadPageIndex();
+      expect(index.pages).toEqual([]);
     });
 
-    it("returns empty index when documents is not an array", () => {
-      mockStorage.setItem(DOCUMENT_INDEX_KEY, JSON.stringify({ version: 1, documents: "bad" }));
-      const index = loadDocumentIndex();
-      expect(index.documents).toEqual([]);
+    it("returns empty index when documents/pages is not an array", () => {
+      mockStorage.setItem(PAGE_INDEX_KEY, JSON.stringify({ version: 1, documents: "bad" }));
+      const index = loadPageIndex();
+      expect(index.pages).toEqual([]);
     });
 
-    it("loads a valid index", () => {
-      const stored: DocumentIndex = {
+    it("loads a valid index (legacy documents format)", () => {
+      const stored = {
         version: 1,
         activeDocumentId: "abc",
         documents: [{ id: "abc", name: "Test", createdAt: "2026-01-01", updatedAt: "2026-01-02" }]
       };
-      mockStorage.setItem(DOCUMENT_INDEX_KEY, JSON.stringify(stored));
-      const index = loadDocumentIndex();
-      expect(index.documents).toHaveLength(1);
-      expect(index.documents[0].name).toBe("Test");
-      expect(index.activeDocumentId).toBe("abc");
+      mockStorage.setItem(PAGE_INDEX_KEY, JSON.stringify(stored));
+      const index = loadPageIndex();
+      expect(index.pages).toHaveLength(1);
+      expect(index.pages[0].name).toBe("Test");
+      expect(index.activePageId).toBe("abc");
     });
 
-    it("filters out invalid document entries", () => {
-      mockStorage.setItem(DOCUMENT_INDEX_KEY, JSON.stringify({
+    it("filters out invalid page entries", () => {
+      mockStorage.setItem(PAGE_INDEX_KEY, JSON.stringify({
         version: 1,
         activeDocumentId: null,
         documents: [
@@ -124,166 +122,121 @@ describe("document-store", () => {
           null
         ]
       }));
-      const index = loadDocumentIndex();
-      expect(index.documents).toHaveLength(1);
-      expect(index.documents[0].id).toBe("ok");
+      const index = loadPageIndex();
+      expect(index.pages).toHaveLength(1);
+      expect(index.pages[0].id).toBe("ok");
     });
   });
 
-  describe("saveDocumentIndex", () => {
+  describe("savePageIndex", () => {
     it("persists the index to localStorage", () => {
-      const index: DocumentIndex = {
+      const index: PageIndex = {
         version: 1,
-        activeDocumentId: "x",
-        documents: [{ id: "x", name: "X", createdAt: "2026-01-01", updatedAt: "2026-01-02" }]
+        activePageId: "x",
+        pages: [{ id: "x", name: "X", createdAt: "2026-01-01", updatedAt: "2026-01-02" }]
       };
-      saveDocumentIndex(index);
-      const raw = mockStorage.getItem(DOCUMENT_INDEX_KEY);
+      savePageIndex(index);
+      const raw = mockStorage.getItem(PAGE_INDEX_KEY);
       expect(raw).not.toBeNull();
       const parsed = JSON.parse(raw!);
-      expect(parsed.activeDocumentId).toBe("x");
+      expect(parsed.activePageId).toBe("x");
     });
   });
 
   // -----------------------------------------------------------------------
-  // loadDocumentState / saveDocumentState
+  // loadPageState / savePageState
   // -----------------------------------------------------------------------
 
-  describe("loadDocumentState", () => {
+  describe("loadPageState", () => {
     it("returns null when no state stored", () => {
-      const result = loadDocumentState("nonexistent", "seyes", DEFAULT_LABELS);
+      const result = loadPageState("nonexistent", "seyes", DEFAULT_LABELS);
       expect(result).toBeNull();
     });
 
     it("loads and validates stored state", () => {
       const state = makeState({ title: "Loaded" });
       mockStorage.setItem("dysmaths-doc-test1", JSON.stringify(state));
-      const result = loadDocumentState("test1", "seyes", DEFAULT_LABELS);
+      const result = loadPageState("test1", "seyes", DEFAULT_LABELS);
       expect(result).not.toBeNull();
       expect(result!.title).toBe("Loaded");
     });
 
     it("returns null for invalid stored state", () => {
       mockStorage.setItem("dysmaths-doc-bad", JSON.stringify({ invalid: true }));
-      const result = loadDocumentState("bad", "seyes", DEFAULT_LABELS);
+      const result = loadPageState("bad", "seyes", DEFAULT_LABELS);
       expect(result).toBeNull();
     });
   });
 
-  describe("saveDocumentState", () => {
+  describe("savePageState", () => {
     it("persists state and updates updatedAt in index", () => {
-      const meta: DocumentMeta = { id: "d1", name: "Doc 1", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" };
-      saveDocumentIndex({ version: 1, activeDocumentId: "d1", documents: [meta] });
+      const meta: PageMeta = { id: "d1", name: "Page 1", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" };
+      savePageIndex({ version: 1, activePageId: "d1", pages: [meta] });
 
       const state = makeState({ title: "Updated" });
-      saveDocumentState("d1", state);
+      savePageState("d1", state);
 
       const raw = mockStorage.getItem("dysmaths-doc-d1");
       expect(raw).not.toBeNull();
       expect(JSON.parse(raw!).title).toBe("Updated");
 
-      const index = loadDocumentIndex();
-      expect(index.documents[0].updatedAt).not.toBe("2026-01-01T00:00:00Z");
+      const index = loadPageIndex();
+      expect(index.pages[0].updatedAt).not.toBe("2026-01-01T00:00:00Z");
     });
   });
 
   // -----------------------------------------------------------------------
-  // createDocument
+  // createPage
   // -----------------------------------------------------------------------
 
-  describe("createDocument", () => {
-    it("creates a document and adds it to the index", () => {
-      const state = makeState({ title: "New Doc" });
-      const meta = createDocument("New Doc", state);
+  describe("createPage", () => {
+    it("creates a page and adds it to the index", () => {
+      const state = makeState({ title: "New Page" });
+      const meta = createPage("New Page", state);
 
-      expect(meta.name).toBe("New Doc");
+      expect(meta.name).toBe("New Page");
       expect(meta.id).toBeTruthy();
 
-      const index = loadDocumentIndex();
-      expect(index.documents).toHaveLength(1);
-      expect(index.activeDocumentId).toBe(meta.id);
+      const index = loadPageIndex();
+      expect(index.pages).toHaveLength(1);
+      expect(index.activePageId).toBe(meta.id);
 
       const stored = mockStorage.getItem(`dysmaths-doc-${meta.id}`);
       expect(stored).not.toBeNull();
     });
 
     it("defaults name to Untitled if empty", () => {
-      const meta = createDocument("", makeState());
+      const meta = createPage("", makeState());
       expect(meta.name).toBe("Untitled");
     });
   });
 
   // -----------------------------------------------------------------------
-  // renameDocument
+  // deletePage
   // -----------------------------------------------------------------------
 
-  describe("renameDocument", () => {
-    it("renames a document in the index", () => {
-      const meta = createDocument("Original", makeState());
-      renameDocument(meta.id, "Renamed");
+  describe("deletePage", () => {
+    it("deletes a page from the index and localStorage", () => {
+      const meta1 = createPage("First", makeState());
+      const meta2 = createPage("Second", makeState());
 
-      const index = loadDocumentIndex();
-      expect(index.documents[0].name).toBe("Renamed");
-    });
+      deletePage(meta1.id);
 
-    it("does nothing for non-existent docId", () => {
-      createDocument("A", makeState());
-      renameDocument("nonexistent", "Renamed");
-      const index = loadDocumentIndex();
-      expect(index.documents[0].name).toBe("A");
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // deleteDocument
-  // -----------------------------------------------------------------------
-
-  describe("deleteDocument", () => {
-    it("deletes a document from the index and localStorage", () => {
-      const meta1 = createDocument("First", makeState());
-      const meta2 = createDocument("Second", makeState());
-
-      deleteDocument(meta1.id);
-
-      const index = loadDocumentIndex();
-      expect(index.documents).toHaveLength(1);
-      expect(index.documents[0].id).toBe(meta2.id);
+      const index = loadPageIndex();
+      expect(index.pages).toHaveLength(1);
+      expect(index.pages[0].id).toBe(meta2.id);
       expect(mockStorage.getItem(`dysmaths-doc-${meta1.id}`)).toBeNull();
     });
 
-    it("switches active document if deleted was active", () => {
-      const meta1 = createDocument("First", makeState());
-      const meta2 = createDocument("Second", makeState());
+    it("switches active page if deleted was active", () => {
+      const meta1 = createPage("First", makeState());
+      const meta2 = createPage("Second", makeState());
 
       // meta2 is active (last created)
-      deleteDocument(meta2.id);
+      deletePage(meta2.id);
 
-      const index = loadDocumentIndex();
-      expect(index.activeDocumentId).toBe(meta1.id);
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // duplicateDocument
-  // -----------------------------------------------------------------------
-
-  describe("duplicateDocument", () => {
-    it("duplicates a document with a new name", () => {
-      const state = makeState({ title: "Original" });
-      const meta = createDocument("Original", state);
-
-      const dup = duplicateDocument(meta.id, "Original (copy)", "seyes", DEFAULT_LABELS);
-
-      expect(dup).not.toBeNull();
-      expect(dup!.name).toBe("Original (copy)");
-
-      const index = loadDocumentIndex();
-      expect(index.documents).toHaveLength(2);
-    });
-
-    it("returns null for non-existent docId", () => {
-      const result = duplicateDocument("nonexistent", "Copy", "seyes", DEFAULT_LABELS);
-      expect(result).toBeNull();
+      const index = loadPageIndex();
+      expect(index.activePageId).toBe(meta1.id);
     });
   });
 
@@ -298,41 +251,41 @@ describe("document-store", () => {
 
       const index = migrateFromLegacyStorage("seyes", DEFAULT_LABELS);
 
-      expect(index.documents).toHaveLength(1);
-      expect(index.documents[0].name).toBe("Legacy Doc");
-      expect(index.activeDocumentId).toBe(index.documents[0].id);
+      expect(index.pages).toHaveLength(1);
+      expect(index.pages[0].name).toBe("Legacy Doc");
+      expect(index.activePageId).toBe(index.pages[0].id);
 
       // Legacy key should be removed
       expect(mockStorage.getItem(STORAGE_KEY)).toBeNull();
 
       // New key should exist
-      expect(mockStorage.getItem(`dysmaths-doc-${index.documents[0].id}`)).not.toBeNull();
+      expect(mockStorage.getItem(`dysmaths-doc-${index.pages[0].id}`)).not.toBeNull();
     });
 
     it("returns empty index if no legacy data", () => {
       const index = migrateFromLegacyStorage("seyes", DEFAULT_LABELS);
-      expect(index.documents).toHaveLength(0);
+      expect(index.pages).toHaveLength(0);
     });
 
     it("cleans up invalid legacy data and returns empty index", () => {
       mockStorage.setItem(STORAGE_KEY, "invalid json");
       const index = migrateFromLegacyStorage("seyes", DEFAULT_LABELS);
-      expect(index.documents).toHaveLength(0);
+      expect(index.pages).toHaveLength(0);
       expect(mockStorage.getItem(STORAGE_KEY)).toBeNull();
     });
   });
 
   // -----------------------------------------------------------------------
-  // exportDocumentToFile
+  // exportPageToFile
   // -----------------------------------------------------------------------
 
-  describe("exportDocumentToFile", () => {
+  describe("exportPageToFile", () => {
     it("calls saveAs with a .dysmaths file", async () => {
       const { saveAs } = await import("file-saver");
-      const meta: DocumentMeta = { id: "e1", name: "Export Test", createdAt: "2026-01-01", updatedAt: "2026-01-02" };
+      const meta: PageMeta = { id: "e1", name: "Export Test", createdAt: "2026-01-01", updatedAt: "2026-01-02" };
       const state = makeState({ title: "Export Test" });
 
-      exportDocumentToFile(meta, state);
+      exportPageToFile(meta, state);
 
       expect(saveAs).toHaveBeenCalledTimes(1);
       const [blob, fileName] = (saveAs as ReturnType<typeof vi.fn>).mock.calls[0];

--- a/tests/unit/document-store.test.ts
+++ b/tests/unit/document-store.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  type DocumentIndex,
+  type DocumentMeta,
+  type DysmathsFile,
+  DOCUMENT_INDEX_KEY,
+  loadDocumentIndex,
+  saveDocumentIndex,
+  loadDocumentState,
+  saveDocumentState,
+  createDocument,
+  renameDocument,
+  deleteDocument,
+  duplicateDocument,
+  migrateFromLegacyStorage,
+  exportDocumentToFile,
+  parseImportedFile
+} from "@/components/math-workbook/document-store";
+import {
+  STORAGE_KEY,
+  WRITER_STATE_SCHEMA_VERSION,
+  createDefaultState,
+  type WriterState
+} from "@/components/math-workbook/shared";
+
+// ---------------------------------------------------------------------------
+// Mock file-saver
+// ---------------------------------------------------------------------------
+
+vi.mock("file-saver", () => ({
+  saveAs: vi.fn()
+}));
+
+// ---------------------------------------------------------------------------
+// Mock localStorage
+// ---------------------------------------------------------------------------
+
+function createMockLocalStorage(): Storage {
+  const store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { for (const key of Object.keys(store)) delete store[key]; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LABELS = {
+  title: "Test document",
+  fullName: "Full name:",
+  className: "Class:",
+  date: "Date:"
+};
+
+function makeState(overrides?: Partial<WriterState>): WriterState {
+  return { ...createDefaultState("seyes", DEFAULT_LABELS), ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("document-store", () => {
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    mockStorage = createMockLocalStorage();
+    Object.defineProperty(window, "localStorage", { value: mockStorage, writable: true });
+    vi.stubGlobal("crypto", { randomUUID: () => `test-uuid-${Math.random().toString(36).slice(2, 8)}` });
+  });
+
+  // -----------------------------------------------------------------------
+  // loadDocumentIndex / saveDocumentIndex
+  // -----------------------------------------------------------------------
+
+  describe("loadDocumentIndex", () => {
+    it("returns empty index when nothing stored", () => {
+      const index = loadDocumentIndex();
+      expect(index.documents).toEqual([]);
+      expect(index.activeDocumentId).toBeNull();
+      expect(index.version).toBe(1);
+    });
+
+    it("returns empty index when stored data is invalid", () => {
+      mockStorage.setItem(DOCUMENT_INDEX_KEY, "not json");
+      const index = loadDocumentIndex();
+      expect(index.documents).toEqual([]);
+    });
+
+    it("returns empty index when documents is not an array", () => {
+      mockStorage.setItem(DOCUMENT_INDEX_KEY, JSON.stringify({ version: 1, documents: "bad" }));
+      const index = loadDocumentIndex();
+      expect(index.documents).toEqual([]);
+    });
+
+    it("loads a valid index", () => {
+      const stored: DocumentIndex = {
+        version: 1,
+        activeDocumentId: "abc",
+        documents: [{ id: "abc", name: "Test", createdAt: "2026-01-01", updatedAt: "2026-01-02" }]
+      };
+      mockStorage.setItem(DOCUMENT_INDEX_KEY, JSON.stringify(stored));
+      const index = loadDocumentIndex();
+      expect(index.documents).toHaveLength(1);
+      expect(index.documents[0].name).toBe("Test");
+      expect(index.activeDocumentId).toBe("abc");
+    });
+
+    it("filters out invalid document entries", () => {
+      mockStorage.setItem(DOCUMENT_INDEX_KEY, JSON.stringify({
+        version: 1,
+        activeDocumentId: null,
+        documents: [
+          { id: "ok", name: "Good", createdAt: "2026-01-01", updatedAt: "2026-01-02" },
+          { id: 123, name: "Bad id" },
+          { name: "No id" },
+          null
+        ]
+      }));
+      const index = loadDocumentIndex();
+      expect(index.documents).toHaveLength(1);
+      expect(index.documents[0].id).toBe("ok");
+    });
+  });
+
+  describe("saveDocumentIndex", () => {
+    it("persists the index to localStorage", () => {
+      const index: DocumentIndex = {
+        version: 1,
+        activeDocumentId: "x",
+        documents: [{ id: "x", name: "X", createdAt: "2026-01-01", updatedAt: "2026-01-02" }]
+      };
+      saveDocumentIndex(index);
+      const raw = mockStorage.getItem(DOCUMENT_INDEX_KEY);
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw!);
+      expect(parsed.activeDocumentId).toBe("x");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // loadDocumentState / saveDocumentState
+  // -----------------------------------------------------------------------
+
+  describe("loadDocumentState", () => {
+    it("returns null when no state stored", () => {
+      const result = loadDocumentState("nonexistent", "seyes", DEFAULT_LABELS);
+      expect(result).toBeNull();
+    });
+
+    it("loads and validates stored state", () => {
+      const state = makeState({ title: "Loaded" });
+      mockStorage.setItem("dysmaths-doc-test1", JSON.stringify(state));
+      const result = loadDocumentState("test1", "seyes", DEFAULT_LABELS);
+      expect(result).not.toBeNull();
+      expect(result!.title).toBe("Loaded");
+    });
+
+    it("returns null for invalid stored state", () => {
+      mockStorage.setItem("dysmaths-doc-bad", JSON.stringify({ invalid: true }));
+      const result = loadDocumentState("bad", "seyes", DEFAULT_LABELS);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("saveDocumentState", () => {
+    it("persists state and updates updatedAt in index", () => {
+      const meta: DocumentMeta = { id: "d1", name: "Doc 1", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" };
+      saveDocumentIndex({ version: 1, activeDocumentId: "d1", documents: [meta] });
+
+      const state = makeState({ title: "Updated" });
+      saveDocumentState("d1", state);
+
+      const raw = mockStorage.getItem("dysmaths-doc-d1");
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!).title).toBe("Updated");
+
+      const index = loadDocumentIndex();
+      expect(index.documents[0].updatedAt).not.toBe("2026-01-01T00:00:00Z");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // createDocument
+  // -----------------------------------------------------------------------
+
+  describe("createDocument", () => {
+    it("creates a document and adds it to the index", () => {
+      const state = makeState({ title: "New Doc" });
+      const meta = createDocument("New Doc", state);
+
+      expect(meta.name).toBe("New Doc");
+      expect(meta.id).toBeTruthy();
+
+      const index = loadDocumentIndex();
+      expect(index.documents).toHaveLength(1);
+      expect(index.activeDocumentId).toBe(meta.id);
+
+      const stored = mockStorage.getItem(`dysmaths-doc-${meta.id}`);
+      expect(stored).not.toBeNull();
+    });
+
+    it("defaults name to Untitled if empty", () => {
+      const meta = createDocument("", makeState());
+      expect(meta.name).toBe("Untitled");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // renameDocument
+  // -----------------------------------------------------------------------
+
+  describe("renameDocument", () => {
+    it("renames a document in the index", () => {
+      const meta = createDocument("Original", makeState());
+      renameDocument(meta.id, "Renamed");
+
+      const index = loadDocumentIndex();
+      expect(index.documents[0].name).toBe("Renamed");
+    });
+
+    it("does nothing for non-existent docId", () => {
+      createDocument("A", makeState());
+      renameDocument("nonexistent", "Renamed");
+      const index = loadDocumentIndex();
+      expect(index.documents[0].name).toBe("A");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deleteDocument
+  // -----------------------------------------------------------------------
+
+  describe("deleteDocument", () => {
+    it("deletes a document from the index and localStorage", () => {
+      const meta1 = createDocument("First", makeState());
+      const meta2 = createDocument("Second", makeState());
+
+      deleteDocument(meta1.id);
+
+      const index = loadDocumentIndex();
+      expect(index.documents).toHaveLength(1);
+      expect(index.documents[0].id).toBe(meta2.id);
+      expect(mockStorage.getItem(`dysmaths-doc-${meta1.id}`)).toBeNull();
+    });
+
+    it("switches active document if deleted was active", () => {
+      const meta1 = createDocument("First", makeState());
+      const meta2 = createDocument("Second", makeState());
+
+      // meta2 is active (last created)
+      deleteDocument(meta2.id);
+
+      const index = loadDocumentIndex();
+      expect(index.activeDocumentId).toBe(meta1.id);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // duplicateDocument
+  // -----------------------------------------------------------------------
+
+  describe("duplicateDocument", () => {
+    it("duplicates a document with a new name", () => {
+      const state = makeState({ title: "Original" });
+      const meta = createDocument("Original", state);
+
+      const dup = duplicateDocument(meta.id, "Original (copy)", "seyes", DEFAULT_LABELS);
+
+      expect(dup).not.toBeNull();
+      expect(dup!.name).toBe("Original (copy)");
+
+      const index = loadDocumentIndex();
+      expect(index.documents).toHaveLength(2);
+    });
+
+    it("returns null for non-existent docId", () => {
+      const result = duplicateDocument("nonexistent", "Copy", "seyes", DEFAULT_LABELS);
+      expect(result).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // migrateFromLegacyStorage
+  // -----------------------------------------------------------------------
+
+  describe("migrateFromLegacyStorage", () => {
+    it("migrates the legacy single-document key", () => {
+      const state = makeState({ title: "Legacy Doc" });
+      mockStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+
+      const index = migrateFromLegacyStorage("seyes", DEFAULT_LABELS);
+
+      expect(index.documents).toHaveLength(1);
+      expect(index.documents[0].name).toBe("Legacy Doc");
+      expect(index.activeDocumentId).toBe(index.documents[0].id);
+
+      // Legacy key should be removed
+      expect(mockStorage.getItem(STORAGE_KEY)).toBeNull();
+
+      // New key should exist
+      expect(mockStorage.getItem(`dysmaths-doc-${index.documents[0].id}`)).not.toBeNull();
+    });
+
+    it("returns empty index if no legacy data", () => {
+      const index = migrateFromLegacyStorage("seyes", DEFAULT_LABELS);
+      expect(index.documents).toHaveLength(0);
+    });
+
+    it("cleans up invalid legacy data and returns empty index", () => {
+      mockStorage.setItem(STORAGE_KEY, "invalid json");
+      const index = migrateFromLegacyStorage("seyes", DEFAULT_LABELS);
+      expect(index.documents).toHaveLength(0);
+      expect(mockStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // exportDocumentToFile
+  // -----------------------------------------------------------------------
+
+  describe("exportDocumentToFile", () => {
+    it("calls saveAs with a .dysmaths file", async () => {
+      const { saveAs } = await import("file-saver");
+      const meta: DocumentMeta = { id: "e1", name: "Export Test", createdAt: "2026-01-01", updatedAt: "2026-01-02" };
+      const state = makeState({ title: "Export Test" });
+
+      exportDocumentToFile(meta, state);
+
+      expect(saveAs).toHaveBeenCalledTimes(1);
+      const [blob, fileName] = (saveAs as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(blob).toBeInstanceOf(Blob);
+      expect(fileName).toBe("Export-Test.dysmaths");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // parseImportedFile
+  // -----------------------------------------------------------------------
+
+  describe("parseImportedFile", () => {
+    it("parses a valid .dysmaths file", () => {
+      const state = makeState({ title: "Imported" });
+      const file: DysmathsFile = {
+        format: "dysmaths",
+        version: 1,
+        schemaVersion: WRITER_STATE_SCHEMA_VERSION,
+        exportedAt: "2026-01-01",
+        name: "Imported Doc",
+        state
+      };
+
+      const result = parseImportedFile(JSON.stringify(file), "seyes", DEFAULT_LABELS);
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("Imported Doc");
+      expect(result!.state.title).toBe("Imported");
+    });
+
+    it("parses a raw WriterState JSON (fallback)", () => {
+      const state = makeState({ title: "Raw Import" });
+      const result = parseImportedFile(JSON.stringify(state), "seyes", DEFAULT_LABELS);
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("Raw Import");
+    });
+
+    it("returns null for invalid JSON", () => {
+      const result = parseImportedFile("not json at all", "seyes", DEFAULT_LABELS);
+      expect(result).toBeNull();
+    });
+
+    it("returns null for valid JSON but invalid state", () => {
+      const result = parseImportedFile(JSON.stringify({ foo: "bar" }), "seyes", DEFAULT_LABELS);
+      expect(result).toBeNull();
+    });
+
+    it("returns null for .dysmaths file with invalid inner state", () => {
+      const file = {
+        format: "dysmaths",
+        version: 1,
+        schemaVersion: 2,
+        exportedAt: "2026-01-01",
+        name: "Bad State",
+        state: { invalid: true }
+      };
+      const result = parseImportedFile(JSON.stringify(file), "seyes", DEFAULT_LABELS);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, ".")
+    }
+  },
+  test: {
+    environment: "jsdom",
+    include: ["tests/unit/**/*.test.ts"]
+  }
+});


### PR DESCRIPTION
## Summary

Reworked based on maintainer feedback (#10 comment) — replaces the multi-document manager with a simpler **pages** system:

- **"Nouveau" button** — creates a new page (visible, child-friendly)
- **Compact page navigator** — `Page X/Y` dropdown to switch between pages, with a delete button (hidden when only 1 page)
- **Discrete file menu** — icon-only button with dropdown for `.dysmaths` import/export + "delete all pages"
- **Transparent migration** from existing localStorage data (backward-compatible keys)
- **No document manager** — avoids users trusting localStorage as a cloud document store
- Translations for all 3 locales (en, fr, es)
- 23 unit tests for the `document-store` module (vitest + jsdom)

### What changed vs the original PR

| Before | After |
|--------|-------|
| "My Documents" modal with rename/duplicate/delete | Removed — no document manager |
| Document switcher (hidden select) | Compact `Page X/Y` dropdown |
| Separate "New" button (reset current) | "Nouveau" button (creates new page) |
| `.dysmaths` export button in toolbar | Moved to discrete file menu dropdown |
| Import via document manager | Moved to file menu dropdown |

### New/modified files
- `components/math-workbook/document-store.ts` — storage layer (PageIndex, CRUD, migration, file I/O)
- `components/math-workbook/presentational.tsx` — page navigator, file menu dropdown
- `components/math-workbook.tsx` — page handlers, extracted `createProfileAwareDefaultState` helper
- `messages/index.ts` — `pages` section for en/fr/es
- `app/globals.css` — styles for page navigator and file menu
- `tests/unit/document-store.test.ts` — 23 unit tests
- `vitest.config.ts` — vitest configuration

## Test plan

- [ ] Open the app with existing localStorage data → verify legacy migration creates a page
- [ ] Click "Nouveau" → verify a new page is created and displayed
- [ ] Use page navigator dropdown to switch between pages → verify content is preserved
- [ ] Delete current page via × button → verify switch to another page
- [ ] Export a page as `.dysmaths` via file menu → verify downloaded JSON
- [ ] Import a `.dysmaths` file via file menu → verify new page appears
- [ ] "Delete all pages" from file menu → verify in-app confirmation modal, then fresh start
- [ ] Click outside dropdown menus → verify they close
- [ ] Run `npm run test:unit` → 23 tests pass
- [ ] Run `npm run build` → production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)