### PR TITLE
Ux improvements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -626,13 +626,15 @@ button {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 0.08rem;
   width: 1.5rem;
+  height: 1.5rem;
   flex-shrink: 0;
   color: color-mix(in srgb, var(--ink) 60%, var(--paper));
 }
 
 .toolbar-color-icon-letter {
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 800;
   line-height: 1;
 }
@@ -660,33 +662,33 @@ button {
 .toolbar-row-format .canvas-quick-action {
   min-width: 1.67rem;
   min-height: 1.67rem;
-  padding: 0.15rem;
+  padding: 0;
   border-radius: 999px;
 }
 
 .toolbar-row-format .canvas-text-color-sample,
 .toolbar-row-format .canvas-text-highlight-sample {
-  width: 1rem;
-  height: 1rem;
+  width: 1.1rem;
+  height: 1.1rem;
 }
 
 .toolbar-row-format .canvas-text-color-chip,
 .toolbar-row-format .canvas-text-highlight-chip {
   min-width: 1.67rem;
   min-height: 1.67rem;
-  padding: 0.15rem;
+  padding: 0;
 }
 
 .toolbar-highlight-shell {
   position: relative;
 }
 
-.toolbar-highlight-button {
+.toolbar-highlight-shell .toolbar-highlight-button {
   display: inline-flex;
   align-items: center;
   gap: 0.42rem;
   min-height: 36px;
-  padding-inline: 0.58rem;
+  padding: 0.34rem 0.62rem;
 }
 
 .chip-button.toolbar-highlight-button-active {
@@ -778,38 +780,35 @@ button {
 
 .toolbar-highlight-portal {
   position: fixed;
-  left: 1rem;
-  top: 50%;
-  transform: translateY(-50%);
   z-index: 51;
 }
 
+.toolbar-background-portal {
+  transform: translateY(-50%);
+  grid-template-columns: repeat(4, 2rem);
+  min-width: max-content;
+  padding: 0.6rem;
+}
+
 .toolbar-highlight-swatch {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.38rem;
-  min-width: 4.2rem;
-  padding: 0.45rem;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1;
+  min-width: 0;
+  min-height: 0;
+  padding: 0.04rem;
   border: 1px solid color-mix(in srgb, var(--line) 84%, white);
-  border-radius: 14px;
+  border-radius: 999px;
   background: rgba(255, 253, 249, 0.98);
-  text-align: left;
 }
 
 .toolbar-highlight-swatch-sample {
   display: block;
   width: 100%;
-  height: 1.15rem;
-  border-radius: 0.45rem;
+  height: 100%;
+  border-radius: 999px;
   background: linear-gradient(90deg, rgba(92, 108, 129, 0.08), rgba(92, 108, 129, 0.14));
-}
-
-.toolbar-highlight-swatch-label {
-  color: var(--ink);
-  font-size: 0.76rem;
-  font-weight: 700;
-  line-height: 1.1;
 }
 
 .toolbar-highlight-swatch-clear .toolbar-highlight-swatch-sample {
@@ -822,7 +821,7 @@ button {
   content: "";
   position: absolute;
   inset: 0.12rem;
-  border-radius: 0.32rem;
+  border-radius: 999px;
   background: linear-gradient(135deg, transparent 44%, color-mix(in srgb, var(--accent) 88%, white) 44%, color-mix(in srgb, var(--accent) 88%, white) 56%, transparent 56%);
 }
 
@@ -833,8 +832,12 @@ button {
 }
 
 .toolbar-highlight-swatch-active {
-  border-color: rgba(31, 45, 61, 0.34);
+  border: 3px solid rgba(31, 45, 61, 0.48);
   box-shadow: inset 0 0 0 1px rgba(31, 45, 61, 0.08);
+}
+
+.toolbar-highlight-swatch-active.toolbar-highlight-swatch-color {
+  box-shadow: inset 0 0 0 2px rgba(255, 253, 249, 0.9);
 }
 
 .toolbar-shortcut-group {
@@ -3789,22 +3792,29 @@ input {
 .canvas-text-color-chip {
   display: grid;
   place-items: center;
-  min-width: 2rem;
-  min-height: 2rem;
-  padding: 0.2rem;
+  min-width: 1.9rem;
+  min-height: 1.9rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .canvas-text-color-chip-active {
-  border-color: rgba(31, 45, 61, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(31, 45, 61, 0.08);
+  box-shadow: none;
 }
 
 .canvas-text-color-sample {
   display: block;
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 1.18rem;
+  height: 1.18rem;
   border-radius: 50%;
-  box-shadow: inset 0 0 0 1px rgba(31, 45, 61, 0.1);
+  box-shadow: none;
+  transition: box-shadow 140ms ease, transform 140ms ease;
+}
+
+.canvas-text-color-chip-active .canvas-text-color-sample {
+  box-shadow: 0 0 0 3px var(--swatch-color);
 }
 
 .align-grid-icon {

--- a/app/globals.css
+++ b/app/globals.css
@@ -711,7 +711,7 @@ button {
   align-items: center;
   gap: 0.42rem;
   min-height: 36px;
-  padding: 0.34rem 0.62rem;
+  padding: 0.34rem 0.62rem 0.34rem 0.72rem;
 }
 
 .chip-button.toolbar-highlight-button-active {
@@ -804,6 +804,12 @@ button {
 .toolbar-highlight-portal {
   position: fixed;
   z-index: 51;
+}
+
+.toolbar-highlight-palette {
+  grid-template-columns: repeat(4, 2rem);
+  min-width: max-content;
+  padding: 0.6rem;
 }
 
 .toolbar-background-portal {

--- a/app/globals.css
+++ b/app/globals.css
@@ -679,6 +679,29 @@ button {
   padding: 0;
 }
 
+.toolbar-style-preview {
+  display: grid;
+  gap: 0.28rem;
+  width: 100%;
+}
+
+.toolbar-style-preview-label {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.toolbar-style-preview-sample {
+  margin: 0;
+  min-height: 2rem;
+  padding: 0.42rem 0.58rem;
+  border: 1px solid color-mix(in srgb, var(--line) 78%, white);
+  border-radius: 12px;
+  background: rgba(255, 253, 249, 0.72);
+  line-height: 1.2;
+}
+
 .toolbar-highlight-shell {
   position: relative;
 }
@@ -895,6 +918,15 @@ button {
   min-width: 2.2rem;
   padding-inline: 0.52rem;
   text-align: center;
+}
+
+.toolbar-shortcut-text {
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.toolbar-text-button-initial {
+  font-weight: 800;
 }
 
 .math-shortcut-glyph {

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -1002,6 +1002,34 @@ export function MathWorkbook() {
   }, [canvasQuickMenu, selectedCount, historyPast.length, historyFuture.length, selectedBlock, selectedGeometry, selectedSymbol, selectedTextBox, selectedStroke]);
 
   useEffect(() => {
+    const handleDocumentMouseDown = (event: MouseEvent) => {
+      if (advancedToolRef.current !== "highlight") {
+        return;
+      }
+
+      const target = event.target;
+
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      if (canvasRef.current?.contains(target)) {
+        return;
+      }
+
+      if (target.closest(".toolbar-highlight-shell") || target.closest(".toolbar-highlight-panel")) {
+        return;
+      }
+
+      setAdvancedTool(null);
+      setOpenMenu(null);
+    };
+
+    document.addEventListener("mousedown", handleDocumentMouseDown);
+    return () => document.removeEventListener("mousedown", handleDocumentMouseDown);
+  }, []);
+
+  useEffect(() => {
     if (pendingInsertTool) {
       setAdvancedTool(null);
       setCanvasQuickMenu(null);
@@ -5077,12 +5105,13 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
   }
 
   function toggleHighlightTool() {
-    if (advancedTool !== "highlight") {
-      activateHighlightTool(state.activeHighlightColor || DEFAULT_HIGHLIGHT_TOOL_COLOR);
-      setOpenMenu("highlight");
-    } else {
-      toggleMenu("highlight");
+    if (advancedTool === "highlight") {
+      setAdvancedTool(null);
+      setOpenMenu(null);
+      return;
     }
+
+    activateHighlightTool(state.activeHighlightColor || DEFAULT_HIGHLIGHT_TOOL_COLOR);
   }
 
   function toggleAdvancedToolMode(tool: AdvancedTool) {

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -542,11 +542,11 @@ export function MathWorkbook() {
     ];
 
     if (selectedItems.length === 0) {
-      return state.activeHighlightColor;
+      return state.activeTextHighlightColor;
     }
 
-    return selectedItems.every((value) => value === selectedItems[0]) ? selectedItems[0] || null : state.activeHighlightColor;
-  }, [selectedBlockIds, selectedSymbolIds, selectedTextBoxIds, state.activeHighlightColor, state.blocks, state.symbols, state.textBoxes]);
+    return selectedItems.every((value) => value === selectedItems[0]) ? selectedItems[0] || null : state.activeTextHighlightColor;
+  }, [selectedBlockIds, selectedSymbolIds, selectedTextBoxIds, state.activeTextHighlightColor, state.blocks, state.symbols, state.textBoxes]);
   const multiSelectionMenuPosition = useMemo(() => {
     if (selectedCount <= 1 || isCanvasInteracting || selectionRect || !canvasRef.current) {
       return null;
@@ -3648,7 +3648,7 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     if (selectedCount === 0) {
       setState((current) => ({
         ...current,
-        activeHighlightColor: nextHighlight
+        activeTextHighlightColor: nextHighlight
       }));
       runCommand("hiliteColor", nextHighlight ?? "transparent");
       return;
@@ -3656,7 +3656,7 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
 
     setState((current) => ({
       ...current,
-      activeHighlightColor: nextHighlight,
+      activeTextHighlightColor: nextHighlight,
       blocks: current.blocks.map((block) =>
         selectedBlockIdsRef.current.includes(block.id) ? { ...block, highlightColor: nextHighlight } : block
       ),
@@ -5412,7 +5412,7 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
                   left: `${insertCursorPreview.x}px`,
                   top: `${insertCursorPreview.y}px`,
                   color: state.activeColor,
-                  backgroundColor: pendingInsertTool?.kind === "text" ? (state.activeHighlightColor ?? "rgba(255, 250, 243, 0.92)") : undefined,
+                  backgroundColor: pendingInsertTool?.kind === "text" ? (state.activeTextHighlightColor ?? "rgba(255, 250, 243, 0.92)") : undefined,
                   fontSize: pendingInsertTool?.kind === "text" ? `${state.activeFontSize}rem` : undefined,
                   fontWeight: pendingInsertTool?.kind === "text" ? state.activeFontWeight : undefined,
                   fontStyle: pendingInsertTool?.kind === "text" ? state.activeFontStyle : undefined,

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -1509,7 +1509,7 @@ export function MathWorkbook() {
 
   function createBlock(type: StructuredTool) {
     const count = state.blocks.length;
-    const defaultFontSize = getDefaultCanvasFontSize(state.sheetStyle);
+    const defaultFontSize = state.activeFontSize;
     const position = {
       x: 80 + (count % 3) * 48,
       y: 140 + count * 34,
@@ -1631,7 +1631,7 @@ export function MathWorkbook() {
   }
 
   function createFloatingSymbol(shortcut: InlineShortcutItem, x: number, y: number) {
-    const defaultFontSize = getDefaultCanvasFontSize(state.sheetStyle);
+    const defaultFontSize = state.activeFontSize;
 
     if (shortcut.id === "sum") {
       return {
@@ -1713,7 +1713,7 @@ export function MathWorkbook() {
     notation: "plain" | "angle" = "plain",
     yOffset = FLOATING_TEXTBOX_Y_OFFSET
   ) {
-    const defaultFontSize = getDefaultCanvasFontSize(state.sheetStyle);
+    const defaultFontSize = state.activeFontSize;
     const defaultNoteFontSize = getDefaultNoteFontSize(state.sheetStyle);
     return {
       id: createId("text"),
@@ -3020,10 +3020,10 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
         placement.y,
         "default",
         "plain",
-        mode === "exact" ? getExactTextBoxVerticalOffset("default") : FLOATING_TEXTBOX_Y_OFFSET
+        mode === "exact" ? 0 : FLOATING_TEXTBOX_Y_OFFSET
       ),
       text: initialText,
-      width: getTextBoxWidth(initialText, getDefaultCanvasFontSize(state.sheetStyle))
+      width: getTextBoxWidth(initialText, state.activeFontSize)
     };
     beginTransientHistorySession("edit");
 
@@ -3545,7 +3545,10 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
 
   function toggleCanvasBold() {
     if (selectedCount === 0) {
-      if (editingTextBoxId) { runCommand("bold"); }
+      setState((current) => ({
+        ...current,
+        activeFontWeight: current.activeFontWeight >= 700 ? 500 : 700
+      }));
       return;
     }
 
@@ -3577,7 +3580,10 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
 
   function toggleCanvasItalic() {
     if (selectedCount === 0) {
-      if (editingTextBoxId) { runCommand("italic"); }
+      setState((current) => ({
+        ...current,
+        activeFontStyle: current.activeFontStyle === "italic" ? "normal" : "italic"
+      }));
       return;
     }
 
@@ -3606,7 +3612,10 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
 
   function toggleCanvasUnderline() {
     if (selectedCount === 0) {
-      if (editingTextBoxId) { runCommand("underline"); }
+      setState((current) => ({
+        ...current,
+        activeUnderline: !current.activeUnderline
+      }));
       return;
     }
 
@@ -3679,12 +3688,15 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
   }
 
   function adjustCanvasSize(direction: "down" | "up") {
+    const delta = direction === "up" ? 0.12 : -0.12;
+
     if (selectedCount === 0) {
-      runCommand("fontSize", direction === "up" ? "5" : "2");
+      setState((current) => ({
+        ...current,
+        activeFontSize: Math.max(0.9, Math.min(2.6, Number((current.activeFontSize + delta).toFixed(2))))
+      }));
       return;
     }
-
-    const delta = direction === "up" ? 0.12 : -0.12;
 
     setState((current) => ({
       ...current,
@@ -4542,7 +4554,7 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     setPendingInsertTool(null);
     event.dataTransfer.effectAllowed = "copy";
     event.dataTransfer.setData("application/x-maths-tool", JSON.stringify(payload));
-    event.dataTransfer.setData("text/plain", payload.kind === "shortcut" ? payload.shortcutId : payload.toolId);
+    event.dataTransfer.setData("text/plain", payload.kind === "shortcut" ? payload.shortcutId : payload.kind === "structured" ? payload.toolId : payload.kind);
     event.dataTransfer.setDragImage(previewNode, offsetX, offsetY);
     setOpenMenu(null);
   }
@@ -4627,6 +4639,11 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     );
 
     handleToolDragEnd();
+
+    if (payload.kind === "text") {
+      createTextBoxAt(position.x, position.y, "exact");
+      return;
+    }
 
     if (payload.kind === "structured") {
       const block = { ...createBlock(payload.toolId), x: position.x, y: position.y };
@@ -5198,13 +5215,16 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
         highlightOptions={workbookUi.highlightOptions}
         activeHighlightColor={state.activeHighlightColor}
         selectedHighlightColor={selectedHighlightColor}
+        activeFontSize={state.activeFontSize}
         openMenu={openMenu}
         selectedCount={selectedCount}
         canInstallApp={canInstallApp}
         isInstalledApp={isInstalledApp}
         onCloseToolsPanel={() => setIsToolsPanelOpen(false)}
         onToggleGeometryTool={toggleGeometryTool}
+        onTextToolDragStart={(event) => handleToolDragStart({kind: "text"}, event)}
         onStructuredToolDragStart={(toolId, event) => handleToolDragStart({kind: "structured", toolId}, event)}
+        onTogglePendingTextTool={() => togglePendingInsertTool({kind: "text"})}
         onShortcutDragStart={(shortcutId, event) => handleToolDragStart({kind: "shortcut", shortcutId}, event)}
         onToolDragEnd={handleToolDragEnd}
         onTogglePendingStructuredTool={(toolId) => togglePendingInsertTool({kind: "structured", toolId})}
@@ -5385,19 +5405,30 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
               onPaste={handlePaste}
             />
 
-            {(pendingInsertTool?.kind === "shortcut" || pendingInsertTool?.kind === "scriptLetter") && insertCursorPreview.visible ? (
+            {(pendingInsertTool?.kind === "shortcut" || pendingInsertTool?.kind === "scriptLetter" || pendingInsertTool?.kind === "text") && insertCursorPreview.visible ? (
               <div
                 className="canvas-insert-anchor"
-                style={{ left: `${insertCursorPreview.x}px`, top: `${insertCursorPreview.y}px`, color: state.activeColor }}
+                style={{
+                  left: `${insertCursorPreview.x}px`,
+                  top: `${insertCursorPreview.y}px`,
+                  color: state.activeColor,
+                  backgroundColor: pendingInsertTool?.kind === "text" ? (state.activeHighlightColor ?? "rgba(255, 250, 243, 0.92)") : undefined,
+                  fontSize: pendingInsertTool?.kind === "text" ? `${state.activeFontSize}rem` : undefined,
+                  fontWeight: pendingInsertTool?.kind === "text" ? state.activeFontWeight : undefined,
+                  fontStyle: pendingInsertTool?.kind === "text" ? state.activeFontStyle : undefined,
+                  textDecoration: pendingInsertTool?.kind === "text" && state.activeUnderline ? "underline" : undefined
+                }}
                 aria-hidden="true"
               >
-                {pendingInsertTool.kind === "scriptLetter"
+                {pendingInsertTool.kind === "text"
+                  ? t("toolbar.text")
+                  : pendingInsertTool.kind === "scriptLetter"
                   ? renderShortcutGlyph({ id: "scriptLetter", label: pendingInsertTool.label })
                   : renderShortcutGlyph(findShortcutById(pendingInsertTool.shortcutId) ?? { id: pendingInsertTool.shortcutId, label: "?" })}
               </div>
             ) : null}
 
-            {((pendingInsertTool && pendingInsertTool.kind !== "shortcut" && pendingInsertTool.kind !== "scriptLetter") || advancedTool === "highlight") && insertCursorPreview.visible ? (
+            {((pendingInsertTool && pendingInsertTool.kind !== "shortcut" && pendingInsertTool.kind !== "scriptLetter" && pendingInsertTool.kind !== "text") || advancedTool === "highlight") && insertCursorPreview.visible ? (
               <div
                 className={`canvas-insert-cursor ${advancedTool === "highlight" ? "canvas-insert-cursor-highlighter" : ""} ${pendingInsertTool?.kind === "shortcut" ? "canvas-insert-cursor-symbol" : ""}`}
                 style={{

--- a/components/math-workbook/presentational.tsx
+++ b/components/math-workbook/presentational.tsx
@@ -1,6 +1,6 @@
-import {useState} from "react";
+import {useRef, useState} from "react";
 import {createPortal} from "react-dom";
-import type {DragEvent as ReactDragEvent, ReactNode, RefObject} from "react";
+import type {CSSProperties as ReactCSSProperties, DragEvent as ReactDragEvent, ReactNode, RefObject} from "react";
 import {localeLabels, type AppLocale} from "@/i18n/routing";
 import {
   renderShortcutGlyph,
@@ -94,7 +94,7 @@ type WorkbookSidebarProps = {
   onToggleCanvasItalic: () => void;
   onToggleCanvasUnderline: () => void;
   onAdjustCanvasSize: (direction: "down" | "up") => void;
-  onToggleMenu: (menu: "highlight" | "settings" | "install") => void;
+  onToggleMenu: (menu: "highlight" | "background" | "settings" | "install") => void;
   onToggleHighlightTool: () => void;
   onActivateHighlightTool: (highlightColor: string) => void;
   onHeaderDelete: () => void;
@@ -162,6 +162,28 @@ export function WorkbookSidebar({
   onSetProfileEditMode
 }: WorkbookSidebarProps) {
   const [isScriptDropdownOpen, setIsScriptDropdownOpen] = useState(false);
+  const backgroundButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [backgroundMenuPosition, setBackgroundMenuPosition] = useState<{ left: number; top: number } | null>(null);
+
+  function openBackgroundMenu() {
+    const rect = backgroundButtonRef.current?.getBoundingClientRect();
+    if (!rect) {
+      setBackgroundMenuPosition(null);
+      onToggleMenu("background");
+      return;
+    }
+
+    setBackgroundMenuPosition({
+      left: rect.right + 12,
+      top: rect.top + rect.height / 2
+    });
+    onToggleMenu("background");
+  }
+
+  function closeBackgroundMenu() {
+    setBackgroundMenuPosition(null);
+    onToggleMenu("background");
+  }
   return (
     <>
       {isToolsPanelOpen ? <button type="button" className="tools-drawer-backdrop" aria-label={t("toolbar.closeTools")} onClick={onCloseToolsPanel} /> : null}
@@ -252,6 +274,21 @@ export function WorkbookSidebar({
             <p className="sidebar-block-label">{t("toolbar.defaultStyle")}</p>
 
             <div className="toolbar-color-row">
+              <button
+                ref={backgroundButtonRef}
+                type="button"
+                className={`canvas-quick-action canvas-text-highlight-chip${openMenu === "background" ? " canvas-text-highlight-chip-active" : ""}`}
+                title={t("toolbar.backgroundColor")}
+                aria-label={t("toolbar.backgroundColor")}
+                aria-expanded={openMenu === "background"}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={openBackgroundMenu}
+              >
+                <svg viewBox="0 0 16 14" width="16" height="14" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden="true">
+                  <rect x="1" y="1" width="14" height="12" rx="2" />
+                  <rect x="3" y="3" width="10" height="8" rx="1" fill={activeHighlightColor ?? "none"} stroke={activeHighlightColor ? "none" : "currentColor"} strokeWidth="0.8" strokeDasharray="2 1.2" />
+                </svg>
+              </button>
               <span className="toolbar-color-icon" title={t("toolbar.textColor")} aria-label={t("toolbar.textColor")}>
                 <span className="toolbar-color-icon-letter" aria-hidden="true">A</span>
                 <span className="toolbar-color-icon-bar" style={{backgroundColor: activeColor}} aria-hidden="true" />
@@ -261,6 +298,7 @@ export function WorkbookSidebar({
                   key={option.id}
                   type="button"
                   className={`canvas-quick-action canvas-text-color-chip${activeColor === option.value ? " canvas-text-color-chip-active" : ""}`}
+                  style={{"--swatch-color": option.value} as ReactCSSProperties}
                   aria-label={option.label}
                   title={option.label}
                   onMouseDown={(event) => event.preventDefault()}
@@ -269,36 +307,44 @@ export function WorkbookSidebar({
                   <span className="canvas-text-color-sample" style={{backgroundColor: option.value}} />
                 </button>
               ))}
-            </div>
-
-            <div className="toolbar-color-row">
-              <span className="toolbar-color-icon" title={t("toolbar.backgroundColor")} aria-label={t("toolbar.backgroundColor")}>
-                <svg viewBox="0 0 16 14" width="16" height="14" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden="true">
-                  <rect x="1" y="1" width="14" height="12" rx="2" />
-                  <rect x="3" y="3" width="10" height="8" rx="1" fill={activeHighlightColor ?? "none"} stroke={activeHighlightColor ? "none" : "currentColor"} strokeWidth="0.8" strokeDasharray="2 1.2" />
-                </svg>
-              </span>
-              <button
-                type="button"
-                className={`canvas-quick-action canvas-text-highlight-chip${activeHighlightColor === null ? " canvas-text-highlight-chip-active" : ""}`}
-                title={t("toolbar.noBackground")}
-                aria-label={t("toolbar.noBackground")}
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => onApplyActiveHighlightColor("")}
-              >∅</button>
-              {highlightOptions.filter((o) => o.value).map((option) => (
-                <button
-                  key={option.id}
-                  type="button"
-                  className={`canvas-quick-action canvas-text-highlight-chip${activeHighlightColor === option.value ? " canvas-text-highlight-chip-active" : ""}`}
-                  aria-label={option.label}
-                  title={option.label}
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => onApplyActiveHighlightColor(option.value)}
-                >
-                  <span className="canvas-text-highlight-sample" style={{backgroundColor: option.value}} />
-                </button>
-              ))}
+              {openMenu === "background" ? createPortal(
+                <div className="toolbar-highlight-backdrop" onMouseDown={closeBackgroundMenu}>
+                  <div
+                    className="toolbar-highlight-panel toolbar-highlight-portal toolbar-background-portal"
+                    role="menu"
+                    aria-label={t("toolbar.backgroundColor")}
+                    onMouseDown={(event) => event.stopPropagation()}
+                    style={backgroundMenuPosition ? {left: `${backgroundMenuPosition.left}px`, top: `${backgroundMenuPosition.top}px`} : undefined}
+                  >
+                    <button
+                      type="button"
+                      className={`toolbar-highlight-swatch toolbar-highlight-swatch-clear ${activeHighlightColor === null ? "toolbar-highlight-swatch-active toolbar-highlight-swatch-color" : ""}`}
+                      aria-label={t("toolbar.noBackground")}
+                      title={t("toolbar.noBackground")}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => onApplyActiveHighlightColor("")}
+                      style={activeHighlightColor === null ? {borderColor: "var(--accent)", boxShadow: "inset 0 0 0 2px var(--accent)"} : undefined}
+                    >
+                      <span className="toolbar-highlight-swatch-sample" />
+                    </button>
+                    {highlightOptions.filter((option) => option.value).map((option) => (
+                      <button
+                        key={option.id}
+                        type="button"
+                        className={`toolbar-highlight-swatch ${option.value === activeHighlightColor ? "toolbar-highlight-swatch-active toolbar-highlight-swatch-color" : ""}`}
+                        aria-label={option.label}
+                        title={option.label}
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => onApplyActiveHighlightColor(option.value)}
+                        style={option.value === activeHighlightColor ? {borderColor: option.value, boxShadow: `inset 0 0 0 2px ${option.value}`} : undefined}
+                      >
+                        <span className="toolbar-highlight-swatch-sample" style={{backgroundColor: option.value}} />
+                      </button>
+                    ))}
+                  </div>
+                </div>,
+                document.body
+              ) : null}
             </div>
 
             <div className="toolbar-color-row">
@@ -1358,6 +1404,7 @@ export function TextFormatMenu({
             key={option.id}
             type="button"
             className={`canvas-quick-action canvas-text-color-chip ${activeColor === option.value ? "canvas-text-color-chip-active" : ""}`}
+            style={{"--swatch-color": option.value} as ReactCSSProperties}
             aria-label={option.label}
             title={option.label}
             onClick={() => onApplyColor(option.value)}

--- a/components/math-workbook/presentational.tsx
+++ b/components/math-workbook/presentational.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState} from "react";
+import {useState} from "react";
 import {createPortal} from "react-dom";
 import type {CSSProperties as ReactCSSProperties, DragEvent as ReactDragEvent, ReactNode, RefObject} from "react";
 import {localeLabels, type AppLocale} from "@/i18n/routing";
@@ -70,6 +70,7 @@ type WorkbookSidebarProps = {
   highlightOptions: HighlightOption[];
   activeHighlightColor: string | null;
   selectedHighlightColor: string | null;
+  activeFontSize: number;
   openMenu: "highlight" | "settings" | "install" | null;
   selectedCount: number;
   activeFontWeight: number;
@@ -80,10 +81,12 @@ type WorkbookSidebarProps = {
   isInstalledApp: boolean;
   onCloseToolsPanel: () => void;
   onToggleGeometryTool: (tool: GeometryTool) => void;
+  onTextToolDragStart: (event: ReactDragEvent<HTMLButtonElement>) => void;
   onStructuredToolDragStart: (toolId: StructuredTool, event: ReactDragEvent<HTMLButtonElement>) => void;
   onShortcutDragStart: (shortcutId: string, event: ReactDragEvent<HTMLButtonElement>) => void;
   onToolDragEnd: () => void;
   onTogglePendingStructuredTool: (toolId: StructuredTool) => void;
+  onTogglePendingTextTool: () => void;
   onTogglePendingShortcut: (shortcutId: string) => void;
   onSelectScriptLetter: (label: string, content: string) => void;
   onToggleAdvancedToolMode: (tool: AdvancedTool) => void;
@@ -94,7 +97,7 @@ type WorkbookSidebarProps = {
   onToggleCanvasItalic: () => void;
   onToggleCanvasUnderline: () => void;
   onAdjustCanvasSize: (direction: "down" | "up") => void;
-  onToggleMenu: (menu: "highlight" | "background" | "settings" | "install") => void;
+  onToggleMenu: (menu: "highlight" | "settings" | "install") => void;
   onToggleHighlightTool: () => void;
   onActivateHighlightTool: (highlightColor: string) => void;
   onHeaderDelete: () => void;
@@ -125,6 +128,7 @@ export function WorkbookSidebar({
   highlightOptions,
   activeHighlightColor,
   selectedHighlightColor,
+  activeFontSize,
   openMenu,
   selectedCount,
   activeFontWeight,
@@ -135,7 +139,9 @@ export function WorkbookSidebar({
   isInstalledApp,
   onCloseToolsPanel,
   onToggleGeometryTool,
+  onTextToolDragStart,
   onStructuredToolDragStart,
+  onTogglePendingTextTool,
   onShortcutDragStart,
   onToolDragEnd,
   onTogglePendingStructuredTool,
@@ -162,28 +168,6 @@ export function WorkbookSidebar({
   onSetProfileEditMode
 }: WorkbookSidebarProps) {
   const [isScriptDropdownOpen, setIsScriptDropdownOpen] = useState(false);
-  const backgroundButtonRef = useRef<HTMLButtonElement | null>(null);
-  const [backgroundMenuPosition, setBackgroundMenuPosition] = useState<{ left: number; top: number } | null>(null);
-
-  function openBackgroundMenu() {
-    const rect = backgroundButtonRef.current?.getBoundingClientRect();
-    if (!rect) {
-      setBackgroundMenuPosition(null);
-      onToggleMenu("background");
-      return;
-    }
-
-    setBackgroundMenuPosition({
-      left: rect.right + 12,
-      top: rect.top + rect.height / 2
-    });
-    onToggleMenu("background");
-  }
-
-  function closeBackgroundMenu() {
-    setBackgroundMenuPosition(null);
-    onToggleMenu("background");
-  }
   return (
     <>
       {isToolsPanelOpen ? <button type="button" className="tools-drawer-backdrop" aria-label={t("toolbar.closeTools")} onClick={onCloseToolsPanel} /> : null}
@@ -191,6 +175,30 @@ export function WorkbookSidebar({
       <header className={`top-toolbar ${isToolsPanelOpen ? "top-toolbar-open" : ""}`}>
         <div className="top-toolbar-inner">
 
+          <div className="toolbar-row toolbar-row-secondary sidebar-block sidebar-block-compact">
+            <p className="sidebar-block-label">{t("toolbar.pencilColor")}</p>
+
+            <div className="toolbar-color-row">
+              <span className="toolbar-color-icon" title={t("toolbar.textColor")} aria-label={t("toolbar.textColor")}>
+                <span className="toolbar-color-icon-letter" aria-hidden="true">A</span>
+                <span className="toolbar-color-icon-bar" style={{backgroundColor: activeColor}} aria-hidden="true" />
+              </span>
+              {colorOptions.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  className={`canvas-quick-action canvas-text-color-chip${activeColor === option.value ? " canvas-text-color-chip-active" : ""}`}
+                  style={{"--swatch-color": option.value} as ReactCSSProperties}
+                  aria-label={option.label}
+                  title={option.label}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => onApplyActiveColor(option.value)}
+                >
+                  <span className="canvas-text-color-sample" style={{backgroundColor: option.value}} />
+                </button>
+              ))}
+            </div>
+          </div>
 
           <div className="toolbar-row toolbar-row-secondary sidebar-block sidebar-block-compact" aria-label={t("toolbar.tools")}>
             <p className="sidebar-block-label">{t("toolbar.tools")}</p>
@@ -214,6 +222,25 @@ export function WorkbookSidebar({
                 onClick={() => onToggleAdvancedToolMode("draw")}
               >
                 ✎
+              </button>
+              <button
+                type="button"
+                className={`toolbar-shortcut toolbar-shortcut-text ${pendingInsertTool?.kind === "text" ? "toolbar-shortcut-active" : ""}`}
+                title={t("toolbar.text")}
+                aria-label={t("toolbar.text")}
+                aria-pressed={pendingInsertTool?.kind === "text"}
+                draggable
+                onDragStart={onTextToolDragStart}
+                onDragEnd={onToolDragEnd}
+                onClick={() => {
+                  if (shouldIgnoreToolbarClick()) {
+                    return;
+                  }
+
+                  onTogglePendingTextTool();
+                }}
+              >
+                <span aria-hidden="true" className="toolbar-text-button-initial">T</span>exte
               </button>
               <div className="toolbar-highlight-shell">
                 <button
@@ -270,81 +297,40 @@ export function WorkbookSidebar({
             </div>
           </div>
 
+          {pendingInsertTool?.kind === "text" ? (
           <div className={`toolbar-row toolbar-row-secondary toolbar-row-format sidebar-block sidebar-block-compact${isElementMenuVisible ? " toolbar-row-disabled" : ""}`} aria-label={t("toolbar.formatting")} aria-disabled={isElementMenuVisible}>
-            <p className="sidebar-block-label">{t("toolbar.defaultStyle")}</p>
+            <p className="sidebar-block-label">{t("toolbar.formatting")}</p>
 
             <div className="toolbar-color-row">
-              <button
-                ref={backgroundButtonRef}
-                type="button"
-                className={`canvas-quick-action canvas-text-highlight-chip${openMenu === "background" ? " canvas-text-highlight-chip-active" : ""}`}
-                title={t("toolbar.backgroundColor")}
-                aria-label={t("toolbar.backgroundColor")}
-                aria-expanded={openMenu === "background"}
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={openBackgroundMenu}
-              >
+              <span className="toolbar-color-icon" title={t("toolbar.backgroundColor")} aria-label={t("toolbar.backgroundColor")}>
                 <svg viewBox="0 0 16 14" width="16" height="14" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden="true">
                   <rect x="1" y="1" width="14" height="12" rx="2" />
-                  <rect x="3" y="3" width="10" height="8" rx="1" fill={activeHighlightColor ?? "none"} stroke={activeHighlightColor ? "none" : "currentColor"} strokeWidth="0.8" strokeDasharray="2 1.2" />
+                  <rect x="3" y="3" width="10" height="8" rx="1" fill={selectedHighlightColor ?? "none"} stroke={selectedHighlightColor ? "none" : "currentColor"} strokeWidth="0.8" strokeDasharray="2 1.2" />
                 </svg>
-              </button>
-              <span className="toolbar-color-icon" title={t("toolbar.textColor")} aria-label={t("toolbar.textColor")}>
-                <span className="toolbar-color-icon-letter" aria-hidden="true">A</span>
-                <span className="toolbar-color-icon-bar" style={{backgroundColor: activeColor}} aria-hidden="true" />
               </span>
-              {colorOptions.map((option) => (
+              <button
+                type="button"
+                className={`canvas-quick-action canvas-text-highlight-chip ${!selectedHighlightColor ? "canvas-text-highlight-chip-active" : ""}`}
+                title={t("toolbar.noBackground")}
+                aria-label={t("toolbar.noBackground")}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => onApplyActiveHighlightColor("")}
+              >
+                <span className="canvas-text-highlight-sample" />
+              </button>
+              {highlightOptions.filter((option) => option.value).map((option) => (
                 <button
                   key={option.id}
                   type="button"
-                  className={`canvas-quick-action canvas-text-color-chip${activeColor === option.value ? " canvas-text-color-chip-active" : ""}`}
-                  style={{"--swatch-color": option.value} as ReactCSSProperties}
+                  className={`canvas-quick-action canvas-text-highlight-chip ${(option.value || null) === selectedHighlightColor ? "canvas-text-highlight-chip-active" : ""}`}
                   aria-label={option.label}
                   title={option.label}
                   onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => onApplyActiveColor(option.value)}
+                  onClick={() => onApplyActiveHighlightColor((option.value || null) === selectedHighlightColor ? "" : option.value)}
                 >
-                  <span className="canvas-text-color-sample" style={{backgroundColor: option.value}} />
+                  <span className="canvas-text-highlight-sample" style={{backgroundColor: option.value}} />
                 </button>
               ))}
-              {openMenu === "background" ? createPortal(
-                <div className="toolbar-highlight-backdrop" onMouseDown={closeBackgroundMenu}>
-                  <div
-                    className="toolbar-highlight-panel toolbar-highlight-portal toolbar-background-portal"
-                    role="menu"
-                    aria-label={t("toolbar.backgroundColor")}
-                    onMouseDown={(event) => event.stopPropagation()}
-                    style={backgroundMenuPosition ? {left: `${backgroundMenuPosition.left}px`, top: `${backgroundMenuPosition.top}px`} : undefined}
-                  >
-                    <button
-                      type="button"
-                      className={`toolbar-highlight-swatch toolbar-highlight-swatch-clear ${activeHighlightColor === null ? "toolbar-highlight-swatch-active toolbar-highlight-swatch-color" : ""}`}
-                      aria-label={t("toolbar.noBackground")}
-                      title={t("toolbar.noBackground")}
-                      onMouseDown={(event) => event.preventDefault()}
-                      onClick={() => onApplyActiveHighlightColor("")}
-                      style={activeHighlightColor === null ? {borderColor: "var(--accent)", boxShadow: "inset 0 0 0 2px var(--accent)"} : undefined}
-                    >
-                      <span className="toolbar-highlight-swatch-sample" />
-                    </button>
-                    {highlightOptions.filter((option) => option.value).map((option) => (
-                      <button
-                        key={option.id}
-                        type="button"
-                        className={`toolbar-highlight-swatch ${option.value === activeHighlightColor ? "toolbar-highlight-swatch-active toolbar-highlight-swatch-color" : ""}`}
-                        aria-label={option.label}
-                        title={option.label}
-                        onMouseDown={(event) => event.preventDefault()}
-                        onClick={() => onApplyActiveHighlightColor(option.value)}
-                        style={option.value === activeHighlightColor ? {borderColor: option.value, boxShadow: `inset 0 0 0 2px ${option.value}`} : undefined}
-                      >
-                        <span className="toolbar-highlight-swatch-sample" style={{backgroundColor: option.value}} />
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-                document.body
-              ) : null}
             </div>
 
             <div className="toolbar-color-row">
@@ -364,7 +350,25 @@ export function WorkbookSidebar({
                 A+
               </button>
             </div>
+
+            <div className="toolbar-style-preview">
+              <p className="toolbar-style-preview-label">{t("toolbar.stylePreview")}</p>
+              <p
+                className="toolbar-style-preview-sample"
+                style={{
+                  color: activeColor,
+                  backgroundColor: selectedHighlightColor ?? "transparent",
+                  fontSize: `${activeFontSize}rem`,
+                  fontWeight: activeFontWeight,
+                  fontStyle: activeFontStyle,
+                  textDecoration: activeUnderline ? "underline" : "none"
+                }}
+              >
+                {t("toolbar.text")}
+              </p>
+            </div>
           </div>
+          ) : null}
 
           <div className="toolbar-row toolbar-row-secondary sidebar-block sidebar-block-compact">
             <p className="sidebar-block-label">{t("toolbar.geometry")}</p>

--- a/components/math-workbook/presentational.tsx
+++ b/components/math-workbook/presentational.tsx
@@ -1,6 +1,6 @@
-import {useState} from "react";
+import {useRef, useState} from "react";
 import {createPortal} from "react-dom";
-import type {CSSProperties as ReactCSSProperties, DragEvent as ReactDragEvent, ReactNode, RefObject} from "react";
+import type {CSSProperties as ReactCSSProperties, DragEvent as ReactDragEvent, MouseEvent as ReactMouseEvent, ReactNode, RefObject} from "react";
 import {localeLabels, type AppLocale} from "@/i18n/routing";
 import {
   renderShortcutGlyph,
@@ -168,6 +168,38 @@ export function WorkbookSidebar({
   onSetProfileEditMode
 }: WorkbookSidebarProps) {
   const [isScriptDropdownOpen, setIsScriptDropdownOpen] = useState(false);
+  const highlightShellRef = useRef<HTMLDivElement | null>(null);
+  const [highlightMenuPosition, setHighlightMenuPosition] = useState<{ left: number; top: number } | null>(null);
+
+  function openHighlightMenu() {
+    const rect = highlightShellRef.current?.getBoundingClientRect();
+
+    if (!rect) {
+      setHighlightMenuPosition(null);
+      onToggleMenu("highlight");
+      return;
+    }
+
+    setHighlightMenuPosition({
+      left: rect.left,
+      top: rect.bottom + 8
+    });
+    onToggleMenu("highlight");
+  }
+
+  function closeHighlightMenu() {
+    setHighlightMenuPosition(null);
+    onToggleMenu("highlight");
+  }
+
+  function handleHighlightButtonClick(_event: ReactMouseEvent<HTMLButtonElement>) {
+    if (openMenu === "highlight") {
+      closeHighlightMenu();
+      return;
+    }
+
+    openHighlightMenu();
+  }
   return (
     <>
       {isToolsPanelOpen ? <button type="button" className="tools-drawer-backdrop" aria-label={t("toolbar.closeTools")} onClick={onCloseToolsPanel} /> : null}
@@ -242,34 +274,33 @@ export function WorkbookSidebar({
               >
                 <span aria-hidden="true" className="toolbar-text-button-initial">T</span>exte
               </button>
-              <div className="toolbar-highlight-shell">
+              <div ref={highlightShellRef} className="toolbar-highlight-shell">
                 <button
                   type="button"
                   className={`chip-button toolbar-highlight-button ${openMenu === "highlight" || advancedTool === "highlight" ? "toolbar-highlight-button-active" : ""}`}
                   aria-label={t("toolbar.highlighter")}
                   title={t("toolbar.highlighter")}
+                  aria-expanded={openMenu === "highlight"}
                   onMouseDown={(event) => event.preventDefault()}
-                  onClick={onToggleHighlightTool}
+                  onClick={handleHighlightButtonClick}
                 >
                   <span className="toolbar-highlight-marker" aria-hidden="true">
                     <span className="toolbar-highlight-marker-tip" />
                     <span className="toolbar-highlight-marker-body" />
-                    <span className="toolbar-highlight-marker-line" style={{backgroundColor: selectedHighlightColor ?? DEFAULT_HIGHLIGHT_TOOL_COLOR}} />
+                    <span className="toolbar-highlight-marker-line" style={{backgroundColor: activeHighlightColor ?? DEFAULT_HIGHLIGHT_TOOL_COLOR}} />
                   </span>
                   <span className="toolbar-highlight-caret" aria-hidden="true">▾</span>
                 </button>
 
                 {openMenu === "highlight" ? createPortal(
-                  <div className="toolbar-highlight-backdrop" onMouseDown={(event) => {
-                    const x = event.clientX;
-                    const y = event.clientY;
-                    onToggleMenu("highlight");
-                    requestAnimationFrame(() => {
-                      const el = document.elementFromPoint(x, y);
-                      if (el instanceof HTMLElement) { el.click(); }
-                    });
-                  }}>
-                    <div className="toolbar-highlight-panel toolbar-highlight-portal" role="menu" aria-label={t("toolbar.chooseHighlighter")} onMouseDown={(event) => event.stopPropagation()}>
+                  <div className="toolbar-highlight-backdrop" onMouseDown={closeHighlightMenu}>
+                    <div
+                      className="toolbar-highlight-panel toolbar-highlight-portal toolbar-highlight-palette"
+                      role="menu"
+                      aria-label={t("toolbar.chooseHighlighter")}
+                      onMouseDown={(event) => event.stopPropagation()}
+                      style={highlightMenuPosition ? {left: `${highlightMenuPosition.left}px`, top: `${highlightMenuPosition.top}px`} : undefined}
+                    >
                       {highlightOptions.map((option) => (
                         <button
                           key={option.id}
@@ -281,7 +312,6 @@ export function WorkbookSidebar({
                           onClick={() => onActivateHighlightTool(option.value)}
                         >
                           <span className="toolbar-highlight-swatch-sample" style={option.value ? {backgroundColor: option.value} : undefined} />
-                          <span className="toolbar-highlight-swatch-label">{option.label}</span>
                         </button>
                       ))}
                     </div>

--- a/components/math-workbook/shared.tsx
+++ b/components/math-workbook/shared.tsx
@@ -6,7 +6,7 @@ import {type AppLocale} from "@/i18n/routing";
 export type StudyMode = "middleSchool" | "highSchool";
 export type SheetStyle = "seyes" | "large-grid" | "small-grid" | "lined" | "blank";
 export type StructuredTool = "fraction" | "addition" | "subtraction" | "multiplication" | "division" | "power" | "root";
-export type UtilityMenu = "highlight" | "settings" | "install" | null;
+export type UtilityMenu = "highlight" | "background" | "settings" | "install" | null;
 export type GeometryTool = "point" | "segment" | "line" | "ray" | "circle" | "measure" | "protractor" | "compass";
 
 export type FractionBlock = {
@@ -507,7 +507,7 @@ export const CANVAS_GRID_LEFT_REM = 4.8;
 export const CANVAS_GRID_TOP_REM = PAPER_LINE_STEP_REM;
 export const MAX_SNAP_THRESHOLD_PX = 10;
 export const CANVAS_LINE_BASELINE_OFFSET_PX = 5;
-export const DEFAULT_ACTIVE_COLOR = "#1f2d3d";
+export const DEFAULT_ACTIVE_COLOR = "#2169b3";
 export const DEFAULT_HIGHLIGHT_TOOL_COLOR = "rgb(255 226 92)";
 export const DEFAULT_SUM_SYMBOL_SIZE = 54;
 export const DEFAULT_INTEGRAL_SYMBOL_SIZE = 60;
@@ -740,7 +740,6 @@ export function createDefaultState(sheetStyle: SheetStyle = "seyes", labels: Def
 
 export const COLOR_OPTION_VALUES = [
   { id: "ink", value: "#1f2d3d" },
-  { id: "orange", value: "#d56f3c" },
   { id: "blue", value: "#2169b3" },
   { id: "green", value: "#2f8f57" },
   { id: "pink", value: "#b54d7a" }

--- a/components/math-workbook/shared.tsx
+++ b/components/math-workbook/shared.tsx
@@ -6,7 +6,7 @@ import {type AppLocale} from "@/i18n/routing";
 export type StudyMode = "middleSchool" | "highSchool";
 export type SheetStyle = "seyes" | "large-grid" | "small-grid" | "lined" | "blank";
 export type StructuredTool = "fraction" | "addition" | "subtraction" | "multiplication" | "division" | "power" | "root";
-export type UtilityMenu = "highlight" | "background" | "settings" | "install" | null;
+export type UtilityMenu = "highlight" | "settings" | "install" | null;
 export type GeometryTool = "point" | "segment" | "line" | "ray" | "circle" | "measure" | "protractor" | "compass";
 
 export type FractionBlock = {
@@ -266,6 +266,7 @@ export type WriterState = {
   sheetStyle: SheetStyle;
   activeColor: string;
   activeHighlightColor: string | null;
+  activeFontSize: number;
   activeFontWeight: number;
   activeFontStyle: "normal" | "italic";
   activeUnderline: boolean;
@@ -348,6 +349,7 @@ export type PendingSelection = {
 } | null;
 
 export type ToolbarDragPayload =
+  | { kind: "text" }
   | { kind: "structured"; toolId: StructuredTool }
   | { kind: "shortcut"; shortcutId: string };
 
@@ -725,7 +727,8 @@ export function createDefaultState(sheetStyle: SheetStyle = "seyes", labels: Def
     mode: "middleSchool",
     sheetStyle,
     activeColor: DEFAULT_ACTIVE_COLOR,
-    activeHighlightColor: "rgba(255, 226, 92, 0.58)",
+    activeHighlightColor: null,
+    activeFontSize: getDefaultCanvasFontSize(sheetStyle),
     activeFontWeight: 500,
     activeFontStyle: "normal",
     activeUnderline: false,
@@ -1899,6 +1902,10 @@ export function parseStoredState(raw: string, fallbackSheetStyle: SheetStyle, la
         typeof (parsed as { activeHighlightColor?: unknown }).activeHighlightColor === "string"
           ? parsed.activeHighlightColor
           : defaultState.activeHighlightColor,
+      activeFontSize:
+        typeof (parsed as { activeFontSize?: unknown }).activeFontSize === "number"
+          ? parsed.activeFontSize
+          : defaultState.activeFontSize,
       activeFontWeight: typeof (parsed as { activeFontWeight?: unknown }).activeFontWeight === "number" ? parsed.activeFontWeight : 500,
       activeFontStyle: (parsed as { activeFontStyle?: unknown }).activeFontStyle === "italic" ? "italic" : "normal",
       activeUnderline: typeof (parsed as { activeUnderline?: unknown }).activeUnderline === "boolean" ? parsed.activeUnderline : false,

--- a/components/math-workbook/shared.tsx
+++ b/components/math-workbook/shared.tsx
@@ -728,7 +728,7 @@ export function createDefaultState(sheetStyle: SheetStyle = "seyes", labels: Def
     mode: "middleSchool",
     sheetStyle,
     activeColor: DEFAULT_ACTIVE_COLOR,
-    activeHighlightColor: null,
+    activeHighlightColor: DEFAULT_HIGHLIGHT_TOOL_COLOR,
     activeTextHighlightColor: null,
     activeFontSize: getDefaultCanvasFontSize(sheetStyle),
     activeFontWeight: 500,

--- a/components/math-workbook/shared.tsx
+++ b/components/math-workbook/shared.tsx
@@ -266,6 +266,7 @@ export type WriterState = {
   sheetStyle: SheetStyle;
   activeColor: string;
   activeHighlightColor: string | null;
+  activeTextHighlightColor: string | null;
   activeFontSize: number;
   activeFontWeight: number;
   activeFontStyle: "normal" | "italic";
@@ -728,6 +729,7 @@ export function createDefaultState(sheetStyle: SheetStyle = "seyes", labels: Def
     sheetStyle,
     activeColor: DEFAULT_ACTIVE_COLOR,
     activeHighlightColor: null,
+    activeTextHighlightColor: null,
     activeFontSize: getDefaultCanvasFontSize(sheetStyle),
     activeFontWeight: 500,
     activeFontStyle: "normal",
@@ -742,8 +744,8 @@ export function createDefaultState(sheetStyle: SheetStyle = "seyes", labels: Def
 }
 
 export const COLOR_OPTION_VALUES = [
-  { id: "ink", value: "#1f2d3d" },
   { id: "blue", value: "#2169b3" },
+  { id: "ink", value: "#1f2d3d" },
   { id: "green", value: "#2f8f57" },
   { id: "pink", value: "#b54d7a" }
 ] as const;
@@ -1902,6 +1904,10 @@ export function parseStoredState(raw: string, fallbackSheetStyle: SheetStyle, la
         typeof (parsed as { activeHighlightColor?: unknown }).activeHighlightColor === "string"
           ? parsed.activeHighlightColor
           : defaultState.activeHighlightColor,
+      activeTextHighlightColor:
+        typeof (parsed as { activeTextHighlightColor?: unknown }).activeTextHighlightColor === "string"
+          ? parsed.activeTextHighlightColor
+          : defaultState.activeTextHighlightColor,
       activeFontSize:
         typeof (parsed as { activeFontSize?: unknown }).activeFontSize === "number"
           ? parsed.activeFontSize

--- a/messages/index.ts
+++ b/messages/index.ts
@@ -32,6 +32,9 @@ type Messages = {
       highSchoolShortcuts: string;
       formatting: string;
       defaultStyle: string;
+      pencilColor: string;
+      text: string;
+      stylePreview: string;
       scriptLetters: string;
       textColor: string;
       backgroundColor: string;
@@ -258,6 +261,9 @@ const en: Messages = {
       highSchoolShortcuts: "High school shortcuts",
       formatting: "Formatting",
       defaultStyle: "Default style",
+      pencilColor: "Pencil color",
+      text: "Text",
+      stylePreview: "Style preview",
       scriptLetters: "Script letters",
       textColor: "Text color",
       backgroundColor: "Background color",
@@ -493,6 +499,9 @@ const fr: Messages = {
       highSchoolShortcuts: "Raccourcis lycée",
       formatting: "Mise en forme",
       defaultStyle: "Style par défaut",
+      pencilColor: "Couleur du crayon",
+      text: "Texte",
+      stylePreview: "Aperçu du style",
       scriptLetters: "Lettres cursives",
       textColor: "Couleur du texte",
       backgroundColor: "Couleur de fond",
@@ -728,6 +737,9 @@ const es: Messages = {
       highSchoolShortcuts: "Atajos de bachillerato",
       formatting: "Formato",
       defaultStyle: "Estilo por defecto",
+      pencilColor: "Color del lapiz",
+      text: "Texto",
+      stylePreview: "Vista previa del estilo",
       scriptLetters: "Letras cursivas",
       textColor: "Color del texto",
       backgroundColor: "Color de fondo",


### PR DESCRIPTION
Summary

This PR reorganizes the left tools sidebar to clearly separate insertion color, text formatting, and the highlighter, while fixing several interaction regressions.

Main changes

Pencil color is now its own dedicated section at the top of the side panel, with blue as the default color and first option.
Text formatting is no longer always visible:
added a Text button in the Tools section
the Formatting panel only appears when text insertion mode is active
added a Style preview that reflects color, background, size, bold, italic, and underline.
Text can now be added to the page both by click placement and by drag and drop from the Text button.
Reworked the active color swatches:
clearer active state
simpler inactive state
better visual alignment.
Fully separated:
the highlighter color
the text background color
so those two tools no longer interfere with each other.
Highlighter:
restored yellow as the default color
compact color palette without labels
palette opens from the highlighter button
automatically deactivates if the palette is closed without choosing a new color
also deactivates when clicking outside the sheet and outside the highlighter UI while active.
Main files changed

[components/math-workbook/presentational.tsx](app://-/index.html?hostId=local)
[components/math-workbook.tsx](app://-/index.html?hostId=local)
[components/math-workbook/shared.tsx](app://-/index.html?hostId=local)
[app/globals.css](app://-/index.html?hostId=local)
[messages/index.ts](app://-/index.html?hostId=local)