### PR TITLE
Multipage pages PDF export

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1414,6 +1414,56 @@ input {
   font-family: var(--font-display);
 }
 
+.document-page-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.7rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 16px;
+  border: 1px solid rgba(222, 218, 207, 0.62);
+  background: rgba(255, 253, 249, 0.7);
+  box-shadow: none;
+}
+
+.document-page-status,
+.document-page-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.document-page-toggle {
+  min-width: 7rem;
+  justify-content: center;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--ink) 78%, white);
+}
+
+.document-page-add {
+  min-height: 1.9rem;
+  padding: 0.28rem 0.58rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  background: rgba(255, 252, 247, 0.72);
+}
+
+.document-file-menu {
+  margin-top: 0.45rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+.document-file-menu .file-menu-toggle {
+  padding: 0.26rem 0.62rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
 .sheet-style-picker {
   display: grid;
   gap: 0.35rem;
@@ -4130,27 +4180,40 @@ input {
   gap: 0.2rem;
 }
 
+.page-nav-arrow,
 .page-nav-toggle {
   appearance: none;
   -webkit-appearance: none;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.35rem;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 600;
-  padding: 0.3rem 0.55rem;
-  border: 1px solid rgba(92, 108, 129, 0.16);
-  border-radius: 8px;
-  background: rgba(255, 252, 247, 0.94);
-  color: var(--ink);
+  padding: 0.24rem 0.48rem;
+  border: 1px solid rgba(92, 108, 129, 0.12);
+  border-radius: 7px;
+  background: rgba(255, 252, 247, 0.78);
+  color: color-mix(in srgb, var(--ink) 82%, white);
   cursor: pointer;
-  min-height: 2rem;
+  min-height: 1.85rem;
   white-space: nowrap;
-  transition: background 0.1s;
+  transition: background 0.1s, color 0.1s, opacity 0.1s;
 }
 
+.page-nav-arrow {
+  width: 1.85rem;
+  padding: 0;
+}
+
+.page-nav-arrow:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+.page-nav-arrow:not(:disabled):hover,
 .page-nav-toggle:hover {
-  background: rgba(92, 108, 129, 0.06);
+  background: rgba(92, 108, 129, 0.045);
 }
 
 .page-menu-dropdown,
@@ -4185,14 +4248,49 @@ input {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.6rem;
-  height: 1.6rem;
-  border: 1px solid rgba(92, 108, 129, 0.12);
-  border-radius: 8px;
-  background: none;
-  color: color-mix(in srgb, var(--ink) 35%, transparent);
+  min-height: 1.85rem;
+  padding: 0.24rem 0.58rem;
+  border: 1px solid rgba(92, 108, 129, 0.1);
+  border-radius: 7px;
+  background: rgba(255, 252, 247, 0.5);
+  color: color-mix(in srgb, var(--ink) 46%, transparent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
   cursor: pointer;
-  transition: color 0.1s, background 0.1s;
+  transition: color 0.1s, background 0.1s, border-color 0.1s, opacity 0.1s;
+}
+
+.page-nav-delete-text {
+  width: auto;
+}
+
+.page-nav-delete:not(:disabled):hover {
+  background: rgba(192, 57, 43, 0.06);
+  border-color: rgba(192, 57, 43, 0.18);
+  color: color-mix(in srgb, #c0392b 72%, var(--ink));
+}
+
+.page-nav-delete:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+@media (max-width: 720px) {
+  .document-page-bar {
+    align-items: stretch;
+  }
+
+  .document-page-status,
+  .document-page-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .document-page-add {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
 }
 
 .page-nav-delete:hover {

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -5383,20 +5383,6 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     setPageIndex(newIndex);
   }
 
-  function handleExportFile() {
-    const targetId = pageIndex.activePageId;
-    if (!targetId) return;
-
-    const meta = pageIndex.pages.find((d) => d.id === targetId);
-    if (!meta) return;
-
-    exportPageToFile(meta, state);
-  }
-
-  function handleImportFile() {
-    fileInputRef.current?.click();
-  }
-
   function destroyPdfImportDocument() {
     const currentDocument = pdfImportDocumentRef.current;
     pdfImportDocumentRef.current = null;
@@ -6080,8 +6066,6 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
               onAddPage={handleNewPage}
               onSwitchPage={handleSwitchPage}
               onDeletePage={handleDeletePage}
-              onExportFile={handleExportFile}
-              onImportFile={handleImportFile}
             />
           ) : null}
           <div className="document-canvas-viewport">

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -18,10 +18,12 @@ import {
 import {useLocale, useTranslations} from "next-intl";
 import Image from "next/image";
 import {toBlob} from "html-to-image";
+import {jsPDF} from "jspdf";
 import {type AppLocale} from "@/i18n/routing";
 import {usePathname, useRouter} from "@/i18n/navigation";
 import {PWA_INSTALLABLE_EVENT, PWA_INSTALLED_EVENT} from "@/components/pwa-registration";
-import {exportWorkbookPdf, exportWorkbookPng, printWorkbook} from "@/components/math-workbook/export-utils";
+import {exportWorkbookPng, renderCanvasImage} from "@/components/math-workbook/export-utils";
+import {safeFileName} from "@/components/math-workbook/shared";
 import {DrawCanvasLayer, GeometryCanvasLayer} from "@/components/math-workbook/canvas-layers";
 import {FloatingMathBlockItem, FloatingMathSymbolItem, FloatingTextBoxItem} from "@/components/math-workbook/canvas-items";
 import {renderArithmeticInlineEditor} from "@/components/math-workbook/inline-editor-arithmetic";
@@ -5661,6 +5663,14 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     setOpenMenu(null);
   }
 
+  function waitForCanvasRefresh() {
+    return new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => resolve());
+      });
+    });
+  }
+
   async function exportPdf() {
     if (!canvasRef.current) {
       return;
@@ -5669,7 +5679,46 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     setIsExporting("pdf");
 
     try {
-      await exportWorkbookPdf(canvasRef.current, state.sheetStyle, state.title, state.sheetBackground);
+      const originalPageId = pageIndex.activePageId;
+      const pageIds = pageIndex.pages.map((page) => page.id);
+      const pdf = new jsPDF({orientation: "portrait", unit: "pt", format: "a4"});
+      const pageWidth = pdf.internal.pageSize.getWidth();
+      const pageHeight = pdf.internal.pageSize.getHeight();
+
+      for (let i = 0; i < pageIds.length; i += 1) {
+        const pageId = pageIds[i];
+        const loaded = loadPageState(pageId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+
+        if (!loaded) {
+          continue;
+        }
+
+        switchToPage(pageId, pageIndex, true);
+        await waitForCanvasRefresh();
+
+        if (!canvasRef.current) {
+          continue;
+        }
+
+        const {imageUrl, cleanup} = await renderCanvasImage(canvasRef.current, loaded.sheetStyle, loaded.sheetBackground);
+
+        try {
+          if (pdf.getNumberOfPages() > 1 || i > 0) {
+            pdf.addPage();
+          }
+
+          pdf.addImage(imageUrl, "PNG", 0, 0, pageWidth, pageHeight);
+        } finally {
+          cleanup();
+        }
+      }
+
+      if (originalPageId && originalPageId !== pageIndex.activePageId) {
+        switchToPage(originalPageId, pageIndex, true);
+        await waitForCanvasRefresh();
+      }
+
+      pdf.save(`${safeFileName(state.title) || "maths-facile"}.pdf`);
     } finally {
       setIsExporting(null);
     }
@@ -5697,7 +5746,95 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     setIsExporting("print");
 
     try {
-      await printWorkbook(canvasRef.current, state.sheetStyle, state.title, state.sheetBackground);
+      const originalPageId = pageIndex.activePageId;
+      const pageIds = pageIndex.pages.map((page) => page.id);
+      const pages: Array<{imageUrl: string}> = [];
+
+      for (const pageId of pageIds) {
+        const loaded = loadPageState(pageId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
+
+        if (!loaded) {
+          continue;
+        }
+
+        switchToPage(pageId, pageIndex, true);
+        await waitForCanvasRefresh();
+
+        if (!canvasRef.current) {
+          continue;
+        }
+
+        const {imageUrl, cleanup} = await renderCanvasImage(canvasRef.current, loaded.sheetStyle, loaded.sheetBackground);
+
+        try {
+          pages.push({imageUrl});
+        } finally {
+          cleanup();
+        }
+      }
+
+      if (originalPageId && originalPageId !== pageIndex.activePageId) {
+        switchToPage(originalPageId, pageIndex, true);
+        await waitForCanvasRefresh();
+      }
+
+      const printWindow = window.open("", "_blank");
+
+      if (!printWindow) {
+        return;
+      }
+
+      const safeTitle = state.title || "maths-facile";
+      printWindow.document.title = `${safeTitle} - impression`;
+      printWindow.document.open();
+      printWindow.document.write(`<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <title>${safeTitle} - impression</title>
+    <style>
+      @page { size: A4 portrait; margin: 0; }
+      html, body {
+        margin: 0;
+        padding: 0;
+        background: white;
+      }
+      body {
+        display: block;
+      }
+      .page {
+        break-after: page;
+        page-break-after: always;
+        width: 210mm;
+        height: 297mm;
+      }
+      .page:last-child {
+        break-after: auto;
+        page-break-after: auto;
+      }
+      img {
+        display: block;
+        width: 210mm;
+        height: 297mm;
+        object-fit: contain;
+      }
+    </style>
+  </head>
+  <body>
+    ${pages
+      .map((page, index) => `<div class="page"><img src="${page.imageUrl}" alt="${safeTitle} - page ${index + 1}" /></div>`)
+      .join("")}
+    <script>
+      const firePrint = () => {
+        window.focus();
+        window.print();
+      };
+      window.addEventListener('load', () => window.setTimeout(firePrint, 80), { once: true });
+      window.addEventListener('afterprint', () => window.close(), { once: true });
+    </script>
+  </body>
+</html>`);
+      printWindow.document.close();
     } finally {
       setIsExporting(null);
     }

--- a/components/math-workbook.tsx
+++ b/components/math-workbook.tsx
@@ -35,6 +35,7 @@ import {
 import {
   CanvasQuickInsertMenu,
   ConfirmResetModal,
+  DocumentPageBar,
   ProfileModal,
   GeometrySettingsMenu,
   GraduatedLineModal,
@@ -647,7 +648,6 @@ export function MathWorkbook() {
   const [profileStore, setProfileStore] = useState<ProfileStore>({ profiles: [], activeProfileId: null });
   const [profileEditMode, setProfileEditMode] = useState<"create" | "edit" | null>(null);
   const [pageIndex, setPageIndex] = useState<PageIndex>({ version: 1, activePageId: null, pages: [] });
-  const [confirmDeleteAllOpen, setConfirmDeleteAllOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const sheetImportInputRef = useRef<HTMLInputElement>(null);
   const pdfImportDocumentRef = useRef<PdfImportDocument | null>(null);
@@ -1163,7 +1163,7 @@ export function MathWorkbook() {
     }
 
     if (index.pages.length === 0) {
-      const defaultState = createDefaultState(defaultSheetStyle, workbookUi.defaultDocumentLabels);
+      const defaultState = createDefaultState(defaultSheetStyle, workbookUi.defaultDocumentLabels, true);
       createPage(workbookUi.defaultDocumentLabels.title, defaultState);
       index = loadPageIndex();
     }
@@ -4480,15 +4480,7 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     finishBlockEditing(blockId);
   }
 
-  function isHeaderTextBox(textBoxId: string) {
-    return state.textBoxes.some((textBox) => textBox.id === textBoxId && textBox.headerField);
-  }
-
   function removeTextBox(textBoxId: string) {
-    if (isHeaderTextBox(textBoxId)) {
-      return;
-    }
-
     setState((current) => ({
       ...current,
       textBoxes: current.textBoxes.filter((textBox) => textBox.id !== textBoxId)
@@ -5290,10 +5282,10 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
 
     return renderBasicInlineEditor(block as FractionBlock | PowerBlock | RootBlock, bindInlineInput as never);
   }
-  function createProfileAwareDefaultState(): WriterState {
+  function createProfileAwareDefaultState(includeDefaultHeaderTextBoxes = false): WriterState {
     const labels = getDocumentLabelsForProfile(activeProfile, workbookUi.defaultDocumentLabels, locale);
     const sheetStyle = activeProfile?.preferredSheetStyle ?? defaultSheetStyle;
-    const newState = createDefaultState(sheetStyle, labels);
+    const newState = createDefaultState(sheetStyle, labels, includeDefaultHeaderTextBoxes);
 
     if (activeProfile) {
       newState.mode = activeProfile.preferredMode;
@@ -5311,9 +5303,16 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
   }
 
   function confirmResetDocument() {
-    const newState = createProfileAwareDefaultState();
+    const newState = createProfileAwareDefaultState(true);
+
+    for (const page of loadPageIndex().pages) {
+      deletePage(page.id);
+    }
+
+    createPage(newState.title, newState);
     clearTransientState();
     setState(newState);
+    setPageIndex(loadPageIndex());
     setConfirmResetState(null);
   }
 
@@ -5334,8 +5333,10 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     }
   }
 
-  function handleSwitchPage(pageId: string) {
-    if (pageId === pageIndex.activePageId) return;
+  function switchToPage(pageId: string, sourceIndex?: PageIndex, forceReload = false) {
+    const baseIndex = sourceIndex ?? loadPageIndex();
+
+    if (!forceReload && pageId === baseIndex.activePageId) return;
 
     const loaded = loadPageState(pageId, defaultSheetStyle, workbookUi.defaultDocumentLabels);
     if (!loaded) return;
@@ -5343,17 +5344,25 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     clearTransientState();
     setState(loaded);
 
-    const newIndex = { ...pageIndex, activePageId: pageId };
+    const newIndex = { ...baseIndex, activePageId: pageId };
     savePageIndex(newIndex);
     setPageIndex(newIndex);
   }
 
+  function handleSwitchPage(pageId: string) {
+    switchToPage(pageId);
+  }
+
   function handleNewPage() {
-    const newState = createProfileAwareDefaultState();
+    const newState = createProfileAwareDefaultState(false);
     createPage(newState.title, newState);
     clearTransientState();
     setState(newState);
     setPageIndex(loadPageIndex());
+  }
+
+  function handleNewDocument() {
+    setConfirmResetState({open: true});
   }
 
   function handleDeletePage(pageId: string) {
@@ -5363,24 +5372,13 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     const wasActive = pageId === pageIndex.activePageId;
     deletePage(pageId);
     const newIndex = loadPageIndex();
-    setPageIndex(newIndex);
 
     if (wasActive && newIndex.pages.length > 0) {
-      handleSwitchPage(newIndex.activePageId ?? newIndex.pages[0].id);
-    }
-  }
-
-  function handleDeleteAllPages() {
-    setConfirmDeleteAllOpen(true);
-  }
-
-  function confirmDeleteAllPages() {
-    for (const page of pageIndex.pages) {
-      deletePage(page.id);
+      switchToPage(newIndex.activePageId ?? newIndex.pages[0].id, newIndex, true);
+      return;
     }
 
-    handleNewPage();
-    setConfirmDeleteAllOpen(false);
+    setPageIndex(newIndex);
   }
 
   function handleExportFile() {
@@ -5395,15 +5393,6 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
 
   function handleImportFile() {
     fileInputRef.current?.click();
-  }
-
-  function getImportedSheetSummary(background: ImportedSheetBackground | null) {
-    if (!background) {
-      return null;
-    }
-
-    const pageLabel = background.pageNumber ? ` • ${t("pages.importedSheetPage", {page: background.pageNumber})}` : "";
-    return `${t("pages.importedSheetSummary", {name: background.sourceName})}${pageLabel}`;
   }
 
   function destroyPdfImportDocument() {
@@ -5501,14 +5490,6 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
     }
 
     setState((current) => ({...current, sheetStyle: nextStyle}));
-  }
-
-  function handleClearImportedSheetBackground() {
-    setState((current) => ({
-      ...current,
-      sheetBackground: null,
-      sheetStyle: current.sheetStyle === "imported" ? defaultSheetStyle : current.sheetStyle
-    }));
   }
 
   function handleFileInputChange(event: ReactChangeEvent<HTMLInputElement>) {
@@ -5939,10 +5920,6 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
           isExporting={isExporting}
           sheetStyle={state.sheetStyle}
           sheetStyleOptions={workbookUi.sheetStyleOptions}
-          hasImportedSheetBackground={Boolean(state.sheetBackground)}
-          importedSheetSummary={getImportedSheetSummary(state.sheetBackground)}
-          pages={pageIndex.pages}
-          activePageId={pageIndex.activePageId}
           onOpenTools={() => setIsToolsPanelOpen(true)}
           onUndo={undoHistory}
           onRedo={redoHistory}
@@ -5950,21 +5927,26 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
           onExportPng={exportPng}
           onPrint={printSheet}
           onSheetStyleChange={handleSheetStyleChange}
-          onImportSheetBackground={handleOpenSheetImport}
-          onClearImportedSheetBackground={handleClearImportedSheetBackground}
-          onNewPage={handleNewPage}
-          onSwitchPage={handleSwitchPage}
-          onDeletePage={handleDeletePage}
-          onDeleteAllPages={handleDeleteAllPages}
-          onExportFile={handleExportFile}
-          onImportFile={handleImportFile}
+          onNewDocument={handleNewDocument}
           profiles={profileStore.profiles}
           activeProfileId={profileStore.activeProfileId}
           onProfileChange={handleProfileChange}
           onSetProfileEditMode={(mode) => { setProfileEditMode(mode); if (mode) setOpenMenu(null); }}
-        />
+        /> 
 
         <div className="editor-sheet">
+          {pageIndex.pages.length > 1 ? (
+            <DocumentPageBar
+              t={t}
+              pages={pageIndex.pages}
+              activePageId={pageIndex.activePageId}
+              onAddPage={handleNewPage}
+              onSwitchPage={handleSwitchPage}
+              onDeletePage={handleDeletePage}
+              onExportFile={handleExportFile}
+              onImportFile={handleImportFile}
+            />
+          ) : null}
           <div className="document-canvas-viewport">
             <div className="document-canvas-stage">
               <div
@@ -6434,6 +6416,16 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
               </div>
             </div>
           </div>
+          {pageIndex.pages.length <= 1 ? (
+            <DocumentPageBar
+              t={t}
+              pages={pageIndex.pages}
+              activePageId={pageIndex.activePageId}
+              onAddPage={handleNewPage}
+              onSwitchPage={handleSwitchPage}
+              onDeletePage={handleDeletePage}
+            />
+          ) : null}
         </div>
       </section>
 
@@ -6475,27 +6467,6 @@ function createGeometryShapeFromDraft(draft: GeometryDraft): Exclude<GeometrySha
         onClose={() => setConfirmResetState(null)}
         onConfirm={confirmResetDocument}
       />
-      {confirmDeleteAllOpen ? (
-        <div className="modal-backdrop" role="presentation" onClick={() => setConfirmDeleteAllOpen(false)}>
-          <section className="block-modal" role="dialog" aria-modal="true" aria-labelledby="delete-all-modal-title" onClick={(event) => event.stopPropagation()}>
-            <div className="block-modal-head">
-              <div>
-                <p className="card-kind">{t("modal.confirmation")}</p>
-                <h2 id="delete-all-modal-title">{t("pages.deleteAll")}</h2>
-                <p className="toolbar-helper">{t("pages.deleteAllConfirm")}</p>
-              </div>
-              <div className="card-actions">
-                <button type="button" className="small-action" onClick={() => setConfirmDeleteAllOpen(false)}>
-                  {t("modal.cancel")}
-                </button>
-                <button type="button" className="small-action primary-inline-action" onClick={confirmDeleteAllPages}>
-                  {t("pages.deleteAll")}
-                </button>
-              </div>
-            </div>
-          </section>
-        </div>
-      ) : null}
       {pdfImportModalState ? (
         <div className="modal-backdrop" role="presentation" onClick={closePdfImportModal}>
           <section className="block-modal imported-sheet-modal" role="dialog" aria-modal="true" aria-labelledby="pdf-import-title" onClick={(event) => event.stopPropagation()}>

--- a/components/math-workbook/export-utils.ts
+++ b/components/math-workbook/export-utils.ts
@@ -129,7 +129,7 @@ function createExportCanvasNode(canvasNode: HTMLDivElement, sheetStyle: SheetSty
   };
 }
 
-async function renderCanvasImage(canvasNode: HTMLDivElement, sheetStyle: SheetStyle, sheetBackground: ImportedSheetBackground | null = null) {
+export async function renderCanvasImage(canvasNode: HTMLDivElement, sheetStyle: SheetStyle, sheetBackground: ImportedSheetBackground | null = null) {
   const exportNode = createExportCanvasNode(canvasNode, sheetStyle, sheetBackground);
 
   try {

--- a/components/math-workbook/presentational.tsx
+++ b/components/math-workbook/presentational.tsx
@@ -718,8 +718,6 @@ type WorkbookActionBarProps = {
   sheetStyleOptions: SheetStyleOption[];
   profiles: UserProfile[];
   activeProfileId: string | null;
-  pages: PageMeta[];
-  activePageId: string | null;
   onOpenTools: () => void;
   onUndo: () => void;
   onRedo: () => void;
@@ -727,16 +725,7 @@ type WorkbookActionBarProps = {
   onExportPng: () => void;
   onPrint: () => void;
   onSheetStyleChange: (sheetStyle: SheetStyle) => void;
-  hasImportedSheetBackground: boolean;
-  importedSheetSummary: string | null;
-  onImportSheetBackground: () => void;
-  onClearImportedSheetBackground: () => void;
-  onNewPage: () => void;
-  onSwitchPage: (pageId: string) => void;
-  onDeletePage: (pageId: string) => void;
-  onDeleteAllPages: () => void;
-  onExportFile: () => void;
-  onImportFile: () => void;
+  onNewDocument: () => void;
   onProfileChange: (profileId: string | null) => void;
   onSetProfileEditMode: (mode: "create" | "edit" | null) => void;
 };
@@ -756,45 +745,13 @@ export function WorkbookActionBar({
   onExportPng,
   onPrint,
   onSheetStyleChange,
-  hasImportedSheetBackground,
-  importedSheetSummary,
-  onImportSheetBackground,
-  onClearImportedSheetBackground,
-  pages,
-  activePageId,
-  onNewPage,
-  onSwitchPage,
-  onDeletePage,
-  onDeleteAllPages,
-  onExportFile,
-  onImportFile,
+  onNewDocument,
   profiles,
   activeProfileId,
   onProfileChange,
   onSetProfileEditMode
 }: WorkbookActionBarProps) {
-  const [fileMenuOpen, setFileMenuOpen] = useState(false);
-  const [pageMenuOpen, setPageMenuOpen] = useState(false);
-  const pageMenuRef = useRef<HTMLDivElement>(null);
-  const fileMenuRef = useRef<HTMLDivElement>(null);
   const activeProfile = profiles.find((p) => p.id === activeProfileId);
-
-  useEffect(() => {
-    if (!fileMenuOpen && !pageMenuOpen) return;
-
-    function handleClickOutside(event: MouseEvent) {
-      const target = event.target as Node;
-      if (fileMenuOpen && fileMenuRef.current && !fileMenuRef.current.contains(target)) {
-        setFileMenuOpen(false);
-      }
-      if (pageMenuOpen && pageMenuRef.current && !pageMenuRef.current.contains(target)) {
-        setPageMenuOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [fileMenuOpen, pageMenuOpen]);
   const initials = activeProfile ? `${activeProfile.firstName.charAt(0)}${activeProfile.lastName.charAt(0)}`.toUpperCase() : null;
 
   function handleSwitcherChange(value: string) {
@@ -868,100 +825,13 @@ export function WorkbookActionBar({
             ))}
           </select>
         </label>
-        {hasImportedSheetBackground ? (
-          <>
-            <button type="button" className="toolbar-action ghost" onClick={onImportSheetBackground}>
-              {t("pages.replaceImportedSheet")}
-            </button>
-            <button type="button" className="toolbar-action ghost" onClick={onClearImportedSheetBackground}>
-              {t("pages.clearImportedSheet")}
-            </button>
-          </>
-        ) : null}
-        {importedSheetSummary ? <span className="sheet-imported-summary">{importedSheetSummary}</span> : null}
-        <button type="button" className="toolbar-action ghost" onClick={onNewPage}>
+        <button type="button" className="toolbar-action ghost" onClick={onNewDocument}>
           <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
-          {t("pages.newPage")}
+          {t("toolbar.newDocument")}
         </button>
-        {pages.length > 1 ? (
-          <div className="page-navigator" ref={pageMenuRef} aria-label={t("pages.page")}>
-            <button type="button" className="page-nav-toggle" onClick={() => setPageMenuOpen(!pageMenuOpen)}>
-              {t("pages.page")} {pages.findIndex((p) => p.id === activePageId) + 1}/{pages.length}
-              <svg viewBox="0 0 10 6" width="10" height="6" aria-hidden="true">
-                <path d="M0 0l5 6 5-6z" fill="currentColor" opacity="0.5" />
-              </svg>
-            </button>
-            {pageMenuOpen ? (
-              <div className="page-menu-dropdown" role="menu">
-                  {pages.map((page, index) => (
-                    <button
-                      key={page.id}
-                      type="button"
-                      className={`file-menu-item${page.id === activePageId ? " page-menu-item-active" : ""}`}
-                      role="menuitem"
-                      onClick={() => { onSwitchPage(page.id); setPageMenuOpen(false); }}
-                    >
-                      {t("pages.page")} {index + 1}
-                    </button>
-                  ))}
-                </div>
-            ) : null}
-            <button
-              type="button"
-              className="page-nav-delete"
-              onClick={() => onDeletePage(activePageId!)}
-              title={t("pages.deletePage")}
-            >
-              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-              </svg>
-            </button>
-          </div>
-        ) : null}
-        <div className="file-menu-wrapper" ref={fileMenuRef}>
-          <button type="button" className="toolbar-action ghost file-menu-toggle" onClick={() => setFileMenuOpen(!fileMenuOpen)} title={t("pages.fileMenu")}>
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" />
-              <polyline points="14 2 14 8 20 8" />
-            </svg>
-          </button>
-          {fileMenuOpen ? (
-              <div className="file-menu-dropdown" role="menu">
-                <button type="button" className="file-menu-item" role="menuitem" onClick={() => { onExportFile(); setFileMenuOpen(false); }}>
-                  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                    <polyline points="7 10 12 15 17 10" />
-                    <line x1="12" y1="15" x2="12" y2="3" />
-                  </svg>
-                  {t("pages.exportFile")}
-                </button>
-                <button type="button" className="file-menu-item" role="menuitem" onClick={() => { onImportFile(); setFileMenuOpen(false); }}>
-                  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                    <polyline points="17 8 12 3 7 8" />
-                    <line x1="12" y1="3" x2="12" y2="15" />
-                  </svg>
-                  {t("pages.importFile")}
-                </button>
-                {pages.length > 1 ? (
-                  <>
-                    <hr className="file-menu-separator" />
-                    <button type="button" className="file-menu-item file-menu-item-danger" role="menuitem" onClick={() => { onDeleteAllPages(); setFileMenuOpen(false); }}>
-                      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <polyline points="3 6 5 6 21 6" />
-                        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                      </svg>
-                      {t("pages.deleteAll")}
-                    </button>
-                  </>
-                ) : null}
-              </div>
-          ) : null}
-        </div>
         <div className="profile-switcher" title={t("profile.switcherHint")}>
           <select
             className="profile-switcher-select"
@@ -987,6 +857,143 @@ export function WorkbookActionBar({
             )}
           </span>
         </div>
+      </div>
+    </div>
+  );
+}
+
+type DocumentPageBarProps = {
+  t: WorkbookTranslator;
+  pages: PageMeta[];
+  activePageId: string | null;
+  onAddPage: () => void;
+  onSwitchPage: (pageId: string) => void;
+  onDeletePage: (pageId: string) => void;
+  onExportFile: () => void;
+  onImportFile: () => void;
+};
+
+export function DocumentPageBar({
+  t,
+  pages,
+  activePageId,
+  onAddPage,
+  onSwitchPage,
+  onDeletePage,
+  onExportFile,
+  onImportFile
+}: DocumentPageBarProps) {
+  const [pageMenuOpen, setPageMenuOpen] = useState(false);
+  const [fileMenuOpen, setFileMenuOpen] = useState(false);
+  const pageMenuRef = useRef<HTMLDivElement>(null);
+  const fileMenuRef = useRef<HTMLDivElement>(null);
+  const activeIndex = Math.max(0, pages.findIndex((page) => page.id === activePageId));
+  const canGoPrevious = activeIndex > 0;
+  const canGoNext = activeIndex < pages.length - 1;
+  const activePage = pages[activeIndex] ?? null;
+
+  useEffect(() => {
+    if (!pageMenuOpen && !fileMenuOpen) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (pageMenuRef.current && !pageMenuRef.current.contains(target)) {
+        setPageMenuOpen(false);
+      }
+      if (fileMenuRef.current && !fileMenuRef.current.contains(target)) {
+        setFileMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [pageMenuOpen, fileMenuOpen]);
+
+  if (pages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="document-page-bar">
+      <div className="document-page-status" ref={pageMenuRef}>
+        <button type="button" className="page-nav-arrow" onClick={() => onSwitchPage(pages[activeIndex - 1].id)} disabled={!canGoPrevious} aria-label={t("pages.previousPage")}>
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        <button type="button" className="page-nav-toggle document-page-toggle" onClick={() => setPageMenuOpen((open) => !open)}>
+          {t("pages.page")} {activeIndex + 1}/{pages.length}
+          <svg viewBox="0 0 10 6" width="10" height="6" aria-hidden="true">
+            <path d="M0 0l5 6 5-6z" fill="currentColor" opacity="0.5" />
+          </svg>
+        </button>
+        <button type="button" className="page-nav-arrow" onClick={() => onSwitchPage(pages[activeIndex + 1].id)} disabled={!canGoNext} aria-label={t("pages.nextPage")}>
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        </button>
+      </div>
+      <div className="document-page-actions">
+        <button
+          type="button"
+          className="page-nav-delete page-nav-delete-text"
+          onClick={() => activePage ? onDeletePage(activePage.id) : undefined}
+          title={t("pages.deletePage")}
+          aria-label={t("pages.deletePage")}
+          disabled={pages.length <= 1 || !activePage}
+        >
+          {t("pages.removeThisPage")}
+        </button>
+        <button type="button" className="toolbar-action secondary document-page-add" onClick={onAddPage}>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          {t("pages.newPage")}
+        </button>
+      </div>
+      {pageMenuOpen ? (
+        <div className="page-menu-dropdown" role="menu">
+          {pages.map((page, index) => (
+            <button
+              key={page.id}
+              type="button"
+              className={`file-menu-item${page.id === activePage?.id ? " page-menu-item-active" : ""}`}
+              role="menuitem"
+              onClick={() => {
+                onSwitchPage(page.id);
+                setPageMenuOpen(false);
+              }}
+            >
+              {t("pages.page")} {index + 1}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <div className="file-menu-wrapper document-file-menu" ref={fileMenuRef}>
+        <button type="button" className="toolbar-action ghost file-menu-toggle" onClick={() => setFileMenuOpen(!fileMenuOpen)} title={t("pages.fileMenu")}>
+          {t("pages.fileMenuLabel")}
+        </button>
+        {fileMenuOpen ? (
+          <div className="file-menu-dropdown" role="menu">
+            <button type="button" className="file-menu-item" role="menuitem" onClick={() => { onExportFile(); setFileMenuOpen(false); }}>
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
+              {t("pages.exportFile")}
+            </button>
+            <button type="button" className="file-menu-item" role="menuitem" onClick={() => { onImportFile(); setFileMenuOpen(false); }}>
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="17 8 12 3 7 8" />
+                <line x1="12" y1="3" x2="12" y2="15" />
+              </svg>
+                {t("pages.importFile")}
+              </button>
+            </div>
+        ) : null}
       </div>
     </div>
   );

--- a/components/math-workbook/presentational.tsx
+++ b/components/math-workbook/presentational.tsx
@@ -869,8 +869,6 @@ type DocumentPageBarProps = {
   onAddPage: () => void;
   onSwitchPage: (pageId: string) => void;
   onDeletePage: (pageId: string) => void;
-  onExportFile: () => void;
-  onImportFile: () => void;
 };
 
 export function DocumentPageBar({
@@ -879,35 +877,28 @@ export function DocumentPageBar({
   activePageId,
   onAddPage,
   onSwitchPage,
-  onDeletePage,
-  onExportFile,
-  onImportFile
+  onDeletePage
 }: DocumentPageBarProps) {
   const [pageMenuOpen, setPageMenuOpen] = useState(false);
-  const [fileMenuOpen, setFileMenuOpen] = useState(false);
   const pageMenuRef = useRef<HTMLDivElement>(null);
-  const fileMenuRef = useRef<HTMLDivElement>(null);
   const activeIndex = Math.max(0, pages.findIndex((page) => page.id === activePageId));
   const canGoPrevious = activeIndex > 0;
   const canGoNext = activeIndex < pages.length - 1;
   const activePage = pages[activeIndex] ?? null;
 
   useEffect(() => {
-    if (!pageMenuOpen && !fileMenuOpen) return;
+    if (!pageMenuOpen) return;
 
     function handleClickOutside(event: MouseEvent) {
       const target = event.target as Node;
       if (pageMenuRef.current && !pageMenuRef.current.contains(target)) {
         setPageMenuOpen(false);
       }
-      if (fileMenuRef.current && !fileMenuRef.current.contains(target)) {
-        setFileMenuOpen(false);
-      }
     }
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [pageMenuOpen, fileMenuOpen]);
+  }, [pageMenuOpen]);
 
   if (pages.length === 0) {
     return null;
@@ -970,31 +961,6 @@ export function DocumentPageBar({
           ))}
         </div>
       ) : null}
-      <div className="file-menu-wrapper document-file-menu" ref={fileMenuRef}>
-        <button type="button" className="toolbar-action ghost file-menu-toggle" onClick={() => setFileMenuOpen(!fileMenuOpen)} title={t("pages.fileMenu")}>
-          {t("pages.fileMenuLabel")}
-        </button>
-        {fileMenuOpen ? (
-          <div className="file-menu-dropdown" role="menu">
-            <button type="button" className="file-menu-item" role="menuitem" onClick={() => { onExportFile(); setFileMenuOpen(false); }}>
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="7 10 12 15 17 10" />
-                <line x1="12" y1="15" x2="12" y2="3" />
-              </svg>
-              {t("pages.exportFile")}
-            </button>
-            <button type="button" className="file-menu-item" role="menuitem" onClick={() => { onImportFile(); setFileMenuOpen(false); }}>
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="17 8 12 3 7 8" />
-                <line x1="12" y1="3" x2="12" y2="15" />
-              </svg>
-                {t("pages.importFile")}
-              </button>
-            </div>
-        ) : null}
-      </div>
     </div>
   );
 }

--- a/components/math-workbook/shared.tsx
+++ b/components/math-workbook/shared.tsx
@@ -734,7 +734,11 @@ export function createDefaultHeaderTextBoxes(sheetStyle: SheetStyle, labels: Def
   ];
 }
 
-export function createDefaultState(sheetStyle: SheetStyle = "seyes", labels: DefaultDocumentLabels = DEFAULT_DOCUMENT_LABELS): WriterState {
+export function createDefaultState(
+  sheetStyle: SheetStyle = "seyes",
+  labels: DefaultDocumentLabels = DEFAULT_DOCUMENT_LABELS,
+  includeDefaultHeaderTextBoxes = true
+): WriterState {
   return {
     schemaVersion: WRITER_STATE_SCHEMA_VERSION,
     title: labels.title,
@@ -751,7 +755,7 @@ export function createDefaultState(sheetStyle: SheetStyle = "seyes", labels: Def
     textHtml: DEFAULT_TEXT_HTML,
     blocks: [],
     symbols: [],
-    textBoxes: createDefaultHeaderTextBoxes(sheetStyle, labels),
+    textBoxes: includeDefaultHeaderTextBoxes ? createDefaultHeaderTextBoxes(sheetStyle, labels) : [],
     strokes: [],
     geometry: []
   };

--- a/messages/index.ts
+++ b/messages/index.ts
@@ -68,6 +68,7 @@ type Messages = {
     pages: {
       newPage: string;
       deletePage: string;
+      removeThisPage: string;
       deletePageConfirm: string;
       deleteAll: string;
       deleteAllConfirm: string;
@@ -76,10 +77,7 @@ type Messages = {
       importFile: string;
       importError: string;
       importSheet: string;
-      replaceImportedSheet: string;
-      clearImportedSheet: string;
       importSheetError: string;
-      importedSheetSummary: string;
       importedSheetPage: string;
       importPdfTitle: string;
       importPdfHelper: string;
@@ -90,6 +88,7 @@ type Messages = {
       loadingPreview: string;
       untitled: string;
       fileMenu: string;
+      fileMenuLabel: string;
     };
     geometryHelper: {
       idle: string;
@@ -325,8 +324,9 @@ const en: Messages = {
       installHelp: "Use the install icon in the address bar or your browser menu to install the app on this device."
     },
     pages: {
-      newPage: "New",
+      newPage: "Add page",
       deletePage: "Delete",
+      removeThisPage: "Remove this page",
       deletePageConfirm: "Delete this page?",
       deleteAll: "Delete all pages",
       deleteAllConfirm: "Delete all pages and start fresh?",
@@ -335,10 +335,7 @@ const en: Messages = {
       importFile: "Open a file",
       importError: "Could not read this file.",
       importSheet: "Import",
-      replaceImportedSheet: "Replace import",
-      clearImportedSheet: "Remove import",
       importSheetError: "Could not import this image or PDF page.",
-      importedSheetSummary: "Imported: {name}",
       importedSheetPage: "Page {page}",
       importPdfTitle: "Choose a PDF page",
       importPdfHelper: "The PDF stays on this device. Only the selected page is rendered and saved as the sheet background.",
@@ -348,7 +345,8 @@ const en: Messages = {
       importThisPage: "Use this page",
       loadingPreview: "Loading preview...",
       untitled: "Untitled",
-      fileMenu: "File"
+      fileMenu: "File",
+      fileMenuLabel: "Import / Export"
     },
     geometryHelper: {
       idle: "Draw precise figures while preserving the sheet scale for printing.",
@@ -593,8 +591,9 @@ const fr: Messages = {
       installHelp: "Utilise l’icône d’installation dans la barre d’adresse ou le menu du navigateur pour installer l’app sur cet appareil."
     },
     pages: {
-      newPage: "Nouveau",
+      newPage: "Ajouter une page",
       deletePage: "Supprimer",
+      removeThisPage: "Retirer cette page",
       deletePageConfirm: "Supprimer cette page ?",
       deleteAll: "Supprimer toutes les pages",
       deleteAllConfirm: "Supprimer toutes les pages et recommencer ?",
@@ -603,10 +602,7 @@ const fr: Messages = {
       importFile: "Ouvrir un fichier",
       importError: "Impossible de lire ce fichier.",
       importSheet: "Importer",
-      replaceImportedSheet: "Remplacer l'import",
-      clearImportedSheet: "Retirer l'import",
       importSheetError: "Impossible d'importer cette image ou cette page PDF.",
-      importedSheetSummary: "Importé : {name}",
       importedSheetPage: "Page {page}",
       importPdfTitle: "Choisir une page du PDF",
       importPdfHelper: "Le PDF reste sur cet appareil. Seule la page choisie est rendue et enregistrée comme fond de feuille.",
@@ -616,7 +612,8 @@ const fr: Messages = {
       importThisPage: "Utiliser cette page",
       loadingPreview: "Chargement de l'aperçu...",
       untitled: "Sans titre",
-      fileMenu: "Fichier"
+      fileMenu: "Fichier",
+      fileMenuLabel: "Importer/Exporter"
     },
     geometryHelper: {
       idle: "Trace des figures précises en gardant l’échelle de la feuille pour l’impression.",
@@ -861,8 +858,9 @@ const es: Messages = {
       installHelp: "Usa el icono de instalación de la barra de direcciones o el menú del navegador para instalar la app en este dispositivo."
     },
     pages: {
-      newPage: "Nuevo",
+      newPage: "Agregar página",
       deletePage: "Eliminar",
+      removeThisPage: "Retirar esta página",
       deletePageConfirm: "¿Eliminar esta página?",
       deleteAll: "Eliminar todas las páginas",
       deleteAllConfirm: "¿Eliminar todas las páginas y empezar de nuevo?",
@@ -871,10 +869,7 @@ const es: Messages = {
       importFile: "Abrir un archivo",
       importError: "No se pudo leer este archivo.",
       importSheet: "Importar",
-      replaceImportedSheet: "Reemplazar importación",
-      clearImportedSheet: "Quitar importación",
       importSheetError: "No se pudo importar esta imagen o esta página PDF.",
-      importedSheetSummary: "Importado: {name}",
       importedSheetPage: "Página {page}",
       importPdfTitle: "Elegir una página del PDF",
       importPdfHelper: "El PDF permanece en este dispositivo. Solo se renderiza y guarda la página elegida como fondo de la hoja.",
@@ -884,7 +879,8 @@ const es: Messages = {
       importThisPage: "Usar esta página",
       loadingPreview: "Cargando vista previa...",
       untitled: "Sin título",
-      fileMenu: "Archivo"
+      fileMenu: "Archivo",
+      fileMenuLabel: "Importar/Exportar"
     },
     geometryHelper: {
       idle: "Traza figuras precisas manteniendo la escala de la hoja para la impresión.",


### PR DESCRIPTION
## Summary
- export PDF multi-pages: chaque page du document est capturée et ajoutée au PDF
- impression multi-pages: génération d’une page imprimée par feuille du document
- restauration de la page active après export/impression

## Notes
- la logique réutilise les états déjà persistés par page
- le PNG reste inchangé et cible toujours la page active

## Verification
- `npm run lint`